### PR TITLE
Add derived key param to more api

### DIFF
--- a/token-core/tcx-btc-kin/src/signer.rs
+++ b/token-core/tcx-btc-kin/src/signer.rs
@@ -1153,7 +1153,6 @@ mod tests {
     }
 
     mod ltc {
-        //todo: test error
         use super::*;
 
         #[test]

--- a/token-core/tcx-crypto/src/crypto.rs
+++ b/token-core/tcx-crypto/src/crypto.rs
@@ -304,6 +304,8 @@ impl Crypto {
     fn derive_key(&self, password: &str) -> Result<Vec<u8>> {
         let mut derived_key: Credential = [0u8; CREDENTIAL_LEN];
         self.kdf.derive_key(password.as_bytes(), &mut derived_key);
+
+        dbg!(hex::encode(derived_key));
         Ok(derived_key.to_vec())
     }
 

--- a/token-core/tcx-migration/src/keystore_upgrade.rs
+++ b/token-core/tcx-migration/src/keystore_upgrade.rs
@@ -576,13 +576,15 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+        assert_eq!(
+            ori,
+            "685634d212eabe016a1cb09d9f1ea1ea757ebe590b9a097d7b1c9379ad280171"
+        );
+
+        let ori = ks.backup(&Key::DerivedKey("1a60471067b6c6a3202e0014de2ce9b2d45fd73e2289b3cc3d8e5b58fe99ff242fd61e9fe63e75abbdc0ed87a50756cc10c57daf1d6297b99ec9a3b174eee017".to_string())).unwrap();
         assert_eq!(
             ori,
             "685634d212eabe016a1cb09d9f1ea1ea757ebe590b9a097d7b1c9379ad280171"
@@ -596,13 +598,15 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+        assert_eq!(
+            ori,
+            "edskS3E5CLrkwHRYAbDvw5xC913C9GGseMcyNGeGbeaD57Yvvi2jqizpAAZyzUtRK626UvkKYdJwCYE9oKMcqFCtJeBpDYcrVH"
+        );
+
+        let ori = ks.backup(&Key::DerivedKey("b009d3c4e961411836028a9fffbea994e03c71f75589a571cd52125884537f2ac165b92e7bc49c7828d4be0c5c05263a306744f0b9dc785142c8562d45ce4345".to_string())).unwrap();
         assert_eq!(
             ori,
             "edskS3E5CLrkwHRYAbDvw5xC913C9GGseMcyNGeGbeaD57Yvvi2jqizpAAZyzUtRK626UvkKYdJwCYE9oKMcqFCtJeBpDYcrVH"
@@ -616,13 +620,13 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+
+        assert_eq!(ori, "TBRMznXcDf2HK2jBKJsqjBpsEdaiaZUBGKN8aKdwTMrPnMNB5UQM");
+        let ori = ks.backup(&Key::DerivedKey("2e70651f06a28d2f6053a90ee55ab8cb14518ab82182cd922926b4239713286ac6746ad4448608fc1599e6f4e0af33c65f70bc5de13a376933e5e145681d0f80".to_string())).unwrap();
+
         assert_eq!(ori, "TBRMznXcDf2HK2jBKJsqjBpsEdaiaZUBGKN8aKdwTMrPnMNB5UQM");
     }
 
@@ -633,13 +637,14 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+
+        assert_eq!(ori, "L1xDTJYPqhofU8DQCiwjStEBr1X6dhiNfweUhxhoRSgYyMJPcZ6B");
+
+        let ori = ks.backup(&Key::DerivedKey("d175dad756f59a59b6a311f2b369802537d92011c8e3bf6dc2dfaf8df00d942648bf83133bd0204ebc43efcbd0ab79a8d5551c8dcf7ae1f67fc2d1d4aff33c06".to_string())).unwrap();
+
         assert_eq!(ori, "L1xDTJYPqhofU8DQCiwjStEBr1X6dhiNfweUhxhoRSgYyMJPcZ6B");
     }
 
@@ -650,13 +655,11 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+        assert!(ori.contains("FDS7ZJpJg4R7Kd2hzfsEc6mtW5iknjZ3UazX76EsnbH74v8"));
+        let ori = ks.backup(&Key::DerivedKey("daa734e276c7420bd7eb6f9d59d39f3072d9ab0c4c0bda09eb410ab930c745302fb39714a2c4ca1935b18d1d216db11455a4c962daf8bf360ba41c65d872a5a8".to_string())).unwrap();
         assert!(ori.contains("FDS7ZJpJg4R7Kd2hzfsEc6mtW5iknjZ3UazX76EsnbH74v8"));
     }
 
@@ -667,13 +670,15 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+
+        let expected_ori =
+            r#"{"Type":"secp256k1","PrivateKey":"o5JgTvwvrZwLPaQ7X2mKLj8nDxcNhZkSvg1UdCJ1xfY="}"#;
+        assert_eq!(ori, expected_ori.as_bytes().to_hex());
+
+        let ori = ks.backup(&Key::DerivedKey("bee56a3cc9e6536dd22a695742ff1b4a00a797fa6c0ddd6f2c3bfd2ec25d05d61918ab3ceaf5c135f771d957889ee2b361c5d70f1911cc8857299d349a0d9ee6".to_string())).unwrap();
         let expected_ori =
             r#"{"Type":"secp256k1","PrivateKey":"o5JgTvwvrZwLPaQ7X2mKLj8nDxcNhZkSvg1UdCJ1xfY="}"#;
         assert_eq!(ori, expected_ori.as_bytes().to_hex());
@@ -686,13 +691,15 @@ mod tests {
         );
         let json = serde_json::from_str(json_str).unwrap();
         let old_ks = KeystoreUpgrade::new(json);
-        let ks = old_ks
-            .upgrade(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.upgrade(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
+
+        let expected_ori =
+            r#"{"Type":"bls","PrivateKey":"i7kO+zxc6QS+v7YygcmUYh7MUYSRes6anigiLhKF808="}"#;
+        assert_eq!(ori, expected_ori.as_bytes().to_hex());
+
+        let ori = ks.backup(&Key::DerivedKey("f3207a9f25adbdae5eff58bb13a9d9be4d763c6d47269fb14e4bd7a59ed667ba7282f1ba40746c60ae842c3f9dfeba91060f29f547ef2a94a66cfee93573ffaa".to_string())).unwrap();
         let expected_ori =
             r#"{"Type":"bls","PrivateKey":"i7kO+zxc6QS+v7YygcmUYh7MUYSRes6anigiLhKF808="}"#;
         assert_eq!(ori, expected_ori.as_bytes().to_hex());

--- a/token-core/tcx-migration/src/migration.rs
+++ b/token-core/tcx-migration/src/migration.rs
@@ -515,13 +515,9 @@ mod tests {
         let json_str =
             include_str!("../../test-data/wallets-ios-2_14_1/9f4acb4a-7431-4c7d-bd25-a19656a86ea0");
         let old_ks = LegacyKeystore::from_json_str(json_str).unwrap();
-        let ks = old_ks
-            .migrate(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.migrate(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
 
         assert_eq!(ori, "L1xDTJYPqhofU8DQCiwjStEBr1X6dhiNfweUhxhoRSgYyMJPcZ6B");
     }
@@ -531,13 +527,9 @@ mod tests {
         let json_str =
             include_str!("../../test-data/wallets-ios-2_14_1/60573d8d-8e83-45c3-85a5-34fbb2aad5e1");
         let old_ks = LegacyKeystore::from_json_str(json_str).unwrap();
-        let ks = old_ks
-            .migrate(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.migrate(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
         // ciphertext is 9b62...
         assert!(ori.contains("9b62a4c07c96ca9b0b82b5b5eae4e7c9b2b7db531a6d2991198eb6809a8c35ac"));
     }
@@ -547,13 +539,9 @@ mod tests {
         let json_str =
             include_str!("../../test-data/wallets-ios-2_14_1/0597526e-105f-425b-bb44-086fc9dc9568");
         let old_ks = LegacyKeystore::from_json_str(json_str).unwrap();
-        let ks = old_ks
-            .migrate(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.migrate(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
 
         assert_eq!(
             ori,
@@ -566,13 +554,9 @@ mod tests {
         let json_str =
             include_str!("../../test-data/wallets-ios-2_14_1/f3615a56-cb03-4aa4-a893-89944e49920d");
         let old_ks = LegacyKeystore::from_json_str(json_str).unwrap();
-        let ks = old_ks
-            .migrate(
-                &Key::DerivedKey("0x79c74b67fc73a255bc66afc1e7c25867a19e6d2afa5b8e3107a472de13201f1924fed05e811e7f5a4c3e72a8a6e047a80393c215412bde239ec7ded520896630".to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::DerivedKey("0x79c74b67fc73a255bc66afc1e7c25867a19e6d2afa5b8e3107a472de13201f1924fed05e811e7f5a4c3e72a8a6e047a80393c215412bde239ec7ded520896630".to_string());
+        let ks = old_ks.migrate(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
 
         assert_eq!(
             ori,
@@ -585,13 +569,9 @@ mod tests {
         let json_str =
             include_str!("../../test-data/wallets-ios-2_14_1/ac59ccc1-285b-47a7-92f5-a6c432cee21a");
         let old_ks = LegacyKeystore::from_json_str(json_str).unwrap();
-        let ks = old_ks
-            .migrate(
-                &Key::Password(TEST_PASSWORD.to_string()),
-                &IdentityNetwork::Mainnet,
-            )
-            .unwrap();
-        let ori = ks.backup(TEST_PASSWORD).unwrap();
+        let key = Key::Password(TEST_PASSWORD.to_string());
+        let ks = old_ks.migrate(&key, &IdentityNetwork::Mainnet).unwrap();
+        let ori = ks.backup(&key).unwrap();
 
         assert_eq!(
             ori,

--- a/token-core/tcx-primitive/src/ecc.rs
+++ b/token-core/tcx-primitive/src/ecc.rs
@@ -29,8 +29,7 @@ pub enum KeyError {
     InvalidChildNumber,
     #[error("cannot_derive_from_hardened_key")]
     CannotDeriveFromHardenedKey,
-    // todo: why use this key?
-    #[error("cannot_derive_key")]
+    #[error("invalid_base58")]
     InvalidBase58,
     #[error("invalid_private_key")]
     InvalidPrivateKey,

--- a/token-core/tcx-proto/src/api.proto
+++ b/token-core/tcx-proto/src/api.proto
@@ -117,7 +117,10 @@ message ExportJsonParam {
 //// verify the password of the keystore
 message WalletKeyParam {
     string id = 1;
-    string password = 2;
+    oneof key {
+        string password = 2;
+        string derivedKey = 3;
+    }
 }
 
 message ExportMnemonicParam {

--- a/token-core/tcx-proto/src/params.proto
+++ b/token-core/tcx-proto/src/params.proto
@@ -192,15 +192,6 @@ message DeriveSubAccountsResult {
     repeated AccountResponse accounts = 1;
 }
 
-message RemoveWalletParam {
-    string id = 1;
-    string password = 2;
-}
-
-message RemoveWalletResult {
-    bool isSuccess = 1;
-}
-
 message EncryptDataToIpfsParam {
     string identifier = 1;
     string content = 2;
@@ -225,7 +216,10 @@ message SignAuthenticationMessageParam {
     uint64 accessTime = 1;
     string identifier = 2 ;
     string deviceToken = 3;
-    string password = 4;
+    oneof key {
+        string password = 4;
+        string derivedKey = 5;
+    }
 }
 
 message SignAuthenticationMessageResult {

--- a/token-core/tcx-substrate/src/address.rs
+++ b/token-core/tcx-substrate/src/address.rs
@@ -12,7 +12,6 @@ pub struct SubstrateAddress(String);
 
 impl Address for SubstrateAddress {
     fn from_public_key(public_key: &TypedPublicKey, coin: &CoinInfo) -> Result<Self> {
-        // todo: TypedPublicKey to public key
         let sr_pk = Sr25519PublicKey::from_slice(&public_key.to_bytes())?;
         let address = match coin.coin.as_str() {
             "KUSAMA" => sr_pk

--- a/token-core/tcx/src/api.rs
+++ b/token-core/tcx/src/api.rs
@@ -196,8 +196,19 @@ pub struct ExportJsonParam {
 pub struct WalletKeyParam {
     #[prost(string, tag = "1")]
     pub id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub password: ::prost::alloc::string::String,
+    #[prost(oneof = "wallet_key_param::Key", tags = "2, 3")]
+    pub key: ::core::option::Option<wallet_key_param::Key>,
+}
+/// Nested message and enum types in `WalletKeyParam`.
+pub mod wallet_key_param {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Key {
+        #[prost(string, tag = "2")]
+        Password(::prost::alloc::string::String),
+        #[prost(string, tag = "3")]
+        DerivedKey(::prost::alloc::string::String),
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -510,20 +521,6 @@ pub struct DeriveSubAccountsResult {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoveWalletParam {
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub password: ::prost::alloc::string::String,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RemoveWalletResult {
-    #[prost(bool, tag = "1")]
-    pub is_success: bool,
-}
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EncryptDataToIpfsParam {
     #[prost(string, tag = "1")]
     pub identifier: ::prost::alloc::string::String,
@@ -563,8 +560,19 @@ pub struct SignAuthenticationMessageParam {
     pub identifier: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub device_token: ::prost::alloc::string::String,
-    #[prost(string, tag = "4")]
-    pub password: ::prost::alloc::string::String,
+    #[prost(oneof = "sign_authentication_message_param::Key", tags = "4, 5")]
+    pub key: ::core::option::Option<sign_authentication_message_param::Key>,
+}
+/// Nested message and enum types in `SignAuthenticationMessageParam`.
+pub mod sign_authentication_message_param {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Key {
+        #[prost(string, tag = "4")]
+        Password(::prost::alloc::string::String),
+        #[prost(string, tag = "5")]
+        DerivedKey(::prost::alloc::string::String),
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
- Add derive key param to more verify_password, delete_keystore, backup, sign_authentication_message, etc...
- backup api accept derived_key except source is keystore*