### PR TITLE
delete all associated keystore when delete_keystore is called

### DIFF
--- a/token-core/tcx/src/handler.rs
+++ b/token-core/tcx/src/handler.rs
@@ -69,6 +69,7 @@ use tcx_primitive::TypedDeterministicPublicKey;
 use tcx_tezos::{encode_tezos_private_key, parse_tezos_private_key};
 
 use crate::macros::{impl_to_key, use_chains};
+use crate::migration::remove_old_keystore_by_id;
 
 use_chains!(
     tcx_btc_kin::bitcoin,
@@ -724,6 +725,8 @@ pub(crate) fn delete_keystore(data: &[u8]) -> Result<Vec<u8>> {
     if keystore.verify_password(&param.key.clone().unwrap().into()) {
         delete_keystore_file(&param.id)?;
         map.remove(&param.id);
+
+        remove_old_keystore_by_id(&param.id.clone());
 
         let rsp = GeneralResult {
             is_success: true,


### PR DESCRIPTION
When migrating a keystore, a _migrated.json file is generated to store the mapping between the migrated file ID and the original file ID.

When deleting a wallet, the corresponding mapping is found and the original keystore is also deleted. If the _migrated.json file is empty, it is also deleted.