### PR TITLE
fix: using legacy enc key

### DIFF
--- a/token-core/tcx-migration/src/legacy_ipfs.rs
+++ b/token-core/tcx-migration/src/legacy_ipfs.rs
@@ -1,0 +1,51 @@
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::io::Read;
+use tcx_constants::{coin_info_from_param, CurveType};
+use tcx_crypto::{Crypto, EncPair, Key};
+use tcx_keystore::identity::Identity;
+use tcx_keystore::keystore::{IdentityNetwork, Keystore, Metadata, Store};
+use tcx_keystore::{
+    fingerprint_from_private_key, fingerprint_from_seed, mnemonic_to_seed, Address, HdKeystore,
+    PrivateKeystore, Result, Source,
+};
+use tcx_primitive::{PrivateKey, Secp256k1PrivateKey, TypedPublicKey};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IpfsInfo {
+    pub identifier: String,
+    pub ipfs_id: String,
+    pub enc_key: String,
+}
+
+pub fn read_legacy_ipfs_info(filepath: &str) -> Result<IpfsInfo> {
+    let mut identify_file = fs::File::open(&filepath)?;
+
+    let mut json_str = String::new();
+    identify_file.read_to_string(&mut json_str)?;
+    let ipfs_info: IpfsInfo = serde_json::from_str(&json_str)?;
+    Ok(ipfs_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_legacy_ipfs_info;
+    #[test]
+    fn test_scan_tcx_legacy_keystores() {
+        let ipfs_info = read_legacy_ipfs_info("../test-data/wallets/identity.json").unwrap();
+        assert_eq!(
+            ipfs_info.identifier,
+            "im18MDKM8hcTykvMmhLnov9m2BaFqsdjoA7cwNg"
+        );
+        assert_eq!(
+            ipfs_info.ipfs_id,
+            "QmSTTidyfa4np9ak9BZP38atuzkCHy4K59oif23f4dNAGU"
+        );
+        assert_eq!(
+            ipfs_info.enc_key,
+            "9513617c9b398edebfb46080a8f0cf6cab6763866bb06daa63503722bea78907"
+        );
+    }
+}

--- a/token-core/tcx-migration/src/lib.rs
+++ b/token-core/tcx-migration/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod keystore_upgrade;
+pub mod legacy_ipfs;
 pub mod migration;

--- a/token-core/tcx/tests/other_test.rs
+++ b/token-core/tcx/tests/other_test.rs
@@ -1,3 +1,5 @@
+use std::fs;
+
 use common::run_test;
 use serial_test::serial;
 
@@ -234,6 +236,35 @@ pub fn test_ipfs_encrypt_and_decrypt() {
         assert!(!resp.encrypted.is_empty());
         let param = DecryptDataFromIpfsParam {
             identifier: wallet.identifier,
+            encrypted: resp.encrypted,
+        };
+        let ret = call_api("decrypt_data_from_ipfs", param).unwrap();
+        let resp: DecryptDataFromIpfsResult =
+            DecryptDataFromIpfsResult::decode(ret.as_slice()).unwrap();
+        assert_eq!(content, resp.content);
+    })
+}
+
+#[test]
+#[serial]
+pub fn test_ipfs_encrypt_and_decrypt_before_migrate() {
+    run_test(|| {
+        fs::copy(
+            "../test-data/wallets/identity.json",
+            "/tmp/imtoken/wallets/identity.json",
+        )
+        .unwrap();
+        let content = "imToken".to_string();
+        let param = EncryptDataToIpfsParam {
+            identifier: "im18MDKM8hcTykvMmhLnov9m2BaFqsdjoA7cwNg".to_string(),
+            content: content.clone(),
+        };
+        let ret = call_api("encrypt_data_to_ipfs", param).unwrap();
+        let resp: EncryptDataToIpfsResult =
+            EncryptDataToIpfsResult::decode(ret.as_slice()).unwrap();
+        assert!(!resp.encrypted.is_empty());
+        let param = DecryptDataFromIpfsParam {
+            identifier: "im18MDKM8hcTykvMmhLnov9m2BaFqsdjoA7cwNg".to_string(),
             encrypted: resp.encrypted,
         };
         let ret = call_api("decrypt_data_from_ipfs", param).unwrap();


### PR DESCRIPTION
- decrypt ipfs data using legacy enc key in identity.json before identity migration