### PR TITLE
fix: cannot migrate old private key eos keystore

### DIFF
--- a/token-core/tcx/src/migration.rs
+++ b/token-core/tcx/src/migration.rs
@@ -292,7 +292,7 @@ fn parse_legacy_kesytore(contents: String) -> Result<LegacyKeystoreResult> {
     let public_key = if let Some(key_paths) = legacy_keystore.key_path_privates {
         key_paths
             .iter()
-            .find(|x| x.derived_mode == "PATH_DIRECTLY")
+            .find(|x| x.derived_mode == Some("PATH_DIRECTLY".to_string()))
             .map(|x| x.public_key.clone())
             .unwrap_or_default()
     } else {

--- a/token-core/tcx/tests/migration_test.rs
+++ b/token-core/tcx/tests/migration_test.rs
@@ -10,8 +10,9 @@ use tcx_atom::transaction::{AtomTxInput, AtomTxOutput};
 
 use prost::Message;
 use tcx::api::{
-    export_mnemonic_param, migrate_keystore_param, wallet_key_param, ExportMnemonicParam,
-    ExportMnemonicResult, MigrateKeystoreParam, MigrateKeystoreResult, SignParam, WalletKeyParam,
+    export_mnemonic_param, migrate_keystore_param, wallet_key_param, BackupResult,
+    ExportMnemonicParam, ExportMnemonicResult, MigrateKeystoreParam, MigrateKeystoreResult,
+    SignParam, WalletKeyParam,
 };
 
 use tcx::handler::encode_message;
@@ -787,5 +788,53 @@ fn test_migrate_duplicate_then_delete_keystore() {
     assert_eq!(
         Path::new("/tmp/token-core-x/wallets/_migrated").exists(),
         false
+    );
+}
+
+#[test]
+#[serial]
+fn test_migrate_android_old_eos_private_keystore() {
+    setup_test("../test-data");
+    let param = MigrateKeystoreParam {
+        id: "0d49aae6-cf73-4ebb-998d-b6312d18361f".to_string(),
+        network: "TESTNET".to_string(),
+        key: Some(migrate_keystore_param::Key::Password(
+            "11111111".to_string(),
+        )),
+    };
+    call_api("migrate_keystore", param).unwrap();
+    let param = WalletKeyParam {
+        id: "0d49aae6-cf73-4ebb-998d-b6312d18361f".to_string(),
+        key: Some(wallet_key_param::Key::Password("11111111".to_string())),
+    };
+    let ret = call_api("backup", param).unwrap();
+    let exported = BackupResult::decode(ret.as_slice()).unwrap().original;
+    assert_eq!(
+        "5KhJeeS5eVDv5DHsFnorDLiJkTeGtMKwmRgyHiVJYzYVd2d1BoP",
+        exported
+    );
+}
+
+#[test]
+#[serial]
+fn test_migrate_ios_old_eos_private_keystore() {
+    setup_test("../test-data");
+    let param = MigrateKeystoreParam {
+        id: "20a9f050-7fd1-4f2c-b7f8-f03c78201f78".to_string(),
+        network: "TESTNET".to_string(),
+        key: Some(migrate_keystore_param::Key::Password(
+            "11111111".to_string(),
+        )),
+    };
+    call_api("migrate_keystore", param).unwrap();
+    let param = WalletKeyParam {
+        id: "20a9f050-7fd1-4f2c-b7f8-f03c78201f78".to_string(),
+        key: Some(wallet_key_param::Key::Password("11111111".to_string())),
+    };
+    let ret = call_api("backup", param).unwrap();
+    let exported = BackupResult::decode(ret.as_slice()).unwrap().original;
+    assert_eq!(
+        "5KhJeeS5eVDv5DHsFnorDLiJkTeGtMKwmRgyHiVJYzYVd2d1BoP",
+        exported
     );
 }

--- a/token-core/test-data/wallets/0d49aae6-cf73-4ebb-998d-b6312d18361f.json
+++ b/token-core/test-data/wallets/0d49aae6-cf73-4ebb-998d-b6312d18361f.json
@@ -1,0 +1,40 @@
+{
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": { "iv": "271d0f7c2ed23dcd277bf45f39ae1efe" },
+    "ciphertext": "72a6f74eb61dfac8b2601146b95409e46903205e6e524593c1af4b665bed6a224a612129512357a4bce8bb19089e7f207bc3a8cfd927745d2956103b62954bb0331ed00d1d92abe69eaf8ec671ee794deacd8393307b0f91a604b6ec02470df8f9d120eeed1b838daa8764882de72c1f48fdc70460cc1508b4592296ef8cfcc1",
+    "kdf": "pbkdf2",
+    "kdfparams": {
+      "c": 10240,
+      "dklen": 32,
+      "prf": "hmac-sha256",
+      "salt": "bc21558b9645d3766b45c2bb154fdffb038cf85e444f0dcaf4d58c912831d1c9"
+    },
+    "mac": "6b909623c3b857880b694a38c5ef2dbcef03d7db13c4fc038fc682afc5feb16b"
+  },
+  "id": "0d49aae6-cf73-4ebb-998d-b6312d18361f",
+  "version": 10001,
+  "address": "imtoken2test",
+  "keyPathPrivates": [
+    {
+      "derivedMode": "IMPORTED",
+      "path": "",
+      "publicKey": "EOS6r37Sr3oDQNqcKDuSC5kzfu8bKs2jVidWDzA2MjBwhFuFfKkrz",
+      "privateKey": {
+        "encStr": "bf7045ee3694daf87e7bd6ecbf0fbf37d2d3c126a7ae305f6804b905c235ff0b",
+        "nonce": "cb797d96bd75d65fb547e29b1fa9df3e"
+      }
+    }
+  ],
+  "imTokenMeta": {
+    "backup": [],
+    "chainType": "EOS",
+    "mode": "NORMAL",
+    "name": "Imported 1",
+    "network": "MAINNET",
+    "passwordHint": "",
+    "source": "WIF",
+    "timestamp": 1709866517,
+    "walletType": "RANDOM"
+  }
+}

--- a/token-core/test-data/wallets/20a9f050-7fd1-4f2c-b7f8-f03c78201f78.json
+++ b/token-core/test-data/wallets/20a9f050-7fd1-4f2c-b7f8-f03c78201f78.json
@@ -1,0 +1,39 @@
+{
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": { "iv": "271d0f7c2ed23dcd277bf45f39ae1efe" },
+    "ciphertext": "72a6f74eb61dfac8b2601146b95409e46903205e6e524593c1af4b665bed6a224a612129512357a4bce8bb19089e7f207bc3a8cfd927745d2956103b62954bb0331ed00d1d92abe69eaf8ec671ee794deacd8393307b0f91a604b6ec02470df8f9d120eeed1b838daa8764882de72c1f48fdc70460cc1508b4592296ef8cfcc1",
+    "kdf": "pbkdf2",
+    "kdfparams": {
+      "c": 10240,
+      "dklen": 32,
+      "prf": "hmac-sha256",
+      "salt": "bc21558b9645d3766b45c2bb154fdffb038cf85e444f0dcaf4d58c912831d1c9"
+    },
+    "mac": "6b909623c3b857880b694a38c5ef2dbcef03d7db13c4fc038fc682afc5feb16b"
+  },
+  "id": "20a9f050-7fd1-4f2c-b7f8-f03c78201f78",
+  "version": 10001,
+  "address": "imtoken2test",
+  "keyPathPrivates": [
+    {
+      "derivedMode": "IMPORTED",
+      "encPrivate": {
+        "encStr": "bf7045ee3694daf87e7bd6ecbf0fbf37d2d3c126a7ae305f6804b905c235ff0b",
+        "nonce": "cb797d96bd75d65fb547e29b1fa9df3e"
+      },
+      "publicKey": "EOS6r37Sr3oDQNqcKDuSC5kzfu8bKs2jVidWDzA2MjBwhFuFfKkrz"
+    }
+  ],
+  "imTokenMeta": {
+    "backup": [],
+    "chainType": "EOS",
+    "mode": "NORMAL",
+    "name": "Imported 1",
+    "network": "MAINNET",
+    "passwordHint": "",
+    "source": "WIF",
+    "timestamp": 1709866517,
+    "walletType": "RANDOM"
+  }
+}


### PR DESCRIPTION
- fix cannot migrate old private key eos keystore