### PR TITLE
fix: cannot migrate old private key ios eos keystore

### DIFF
--- a/token-core/tcx-migration/src/migration.rs
+++ b/token-core/tcx-migration/src/migration.rs
@@ -154,7 +154,8 @@ impl LegacyKeystore {
     }
 
     fn has_mnemonic(&self) -> bool {
-        self.enc_mnemonic.is_some()
+        // EOS wallet in iOS will contains an empty encMnemonic object, check the 20a9f050-7fd1-4f2c-b7f8-f03c78201f78 fixture kesytore
+        self.enc_mnemonic.is_some() && self.enc_mnemonic.as_ref().unwrap().enc_str != ""
     }
 
     pub fn from_json_str(keystore_str: &str) -> Result<LegacyKeystore> {

--- a/token-core/test-data/wallets/20a9f050-7fd1-4f2c-b7f8-f03c78201f78.json
+++ b/token-core/test-data/wallets/20a9f050-7fd1-4f2c-b7f8-f03c78201f78.json
@@ -1,39 +1,44 @@
 {
-  "crypto": {
-    "cipher": "aes-128-ctr",
-    "cipherparams": { "iv": "271d0f7c2ed23dcd277bf45f39ae1efe" },
-    "ciphertext": "72a6f74eb61dfac8b2601146b95409e46903205e6e524593c1af4b665bed6a224a612129512357a4bce8bb19089e7f207bc3a8cfd927745d2956103b62954bb0331ed00d1d92abe69eaf8ec671ee794deacd8393307b0f91a604b6ec02470df8f9d120eeed1b838daa8764882de72c1f48fdc70460cc1508b4592296ef8cfcc1",
-    "kdf": "pbkdf2",
-    "kdfparams": {
-      "c": 10240,
-      "dklen": 32,
-      "prf": "hmac-sha256",
-      "salt": "bc21558b9645d3766b45c2bb154fdffb038cf85e444f0dcaf4d58c912831d1c9"
-    },
-    "mac": "6b909623c3b857880b694a38c5ef2dbcef03d7db13c4fc038fc682afc5feb16b"
-  },
-  "id": "20a9f050-7fd1-4f2c-b7f8-f03c78201f78",
   "version": 10001,
+  "id": "20a9f050-7fd1-4f2c-b7f8-f03c78201f78",
+  "encMnemonic": { "encStr": "", "nonce": "" },
   "address": "imtoken2test",
   "keyPathPrivates": [
     {
+      "path": "",
       "derivedMode": "IMPORTED",
-      "encPrivate": {
-        "encStr": "bf7045ee3694daf87e7bd6ecbf0fbf37d2d3c126a7ae305f6804b905c235ff0b",
-        "nonce": "cb797d96bd75d65fb547e29b1fa9df3e"
+      "privateKey": {
+        "encStr": "13670678526669a12be40e9068a9c6565a0a8e92899f04790aff4b9cd12f4c76",
+        "nonce": "e870f1a76b63415f0d41264e6355148f"
       },
       "publicKey": "EOS6r37Sr3oDQNqcKDuSC5kzfu8bKs2jVidWDzA2MjBwhFuFfKkrz"
     }
   ],
   "imTokenMeta": {
-    "backup": [],
-    "chainType": "EOS",
-    "mode": "NORMAL",
-    "name": "Imported 1",
-    "network": "MAINNET",
-    "passwordHint": "",
     "source": "WIF",
-    "timestamp": 1709866517,
-    "walletType": "RANDOM"
+    "backup": [],
+    "mode": "normal",
+    "chain": "EOS",
+    "timestamp": "1710142425.79249",
+    "passwordHint": "",
+    "version": "iOS-2.14.1.1742",
+    "network": "TESTNET",
+    "segWit": "NONE",
+    "name": "Imported 1"
+  },
+  "mnemonicPath": "",
+  "crypto": {
+    "kdfparams": {
+      "n": 262144,
+      "salt": "aa3be513f461fb24392618ef1ff2011b200c9766130fe872ea2b3816aef0eda8",
+      "p": 1,
+      "r": 8,
+      "dklen": 32
+    },
+    "mac": "bc3573343cd1a64e9e5f73c972c2d4772b63c838b871f406835984c737f91740",
+    "ciphertext": "12ea4c0653df8fe9e1bff6f6abd1cefb0df14ae50483c35a18f7ea6309edaaca303d7e8fd392baf4019ec0fcbd361c8f563c612dc067195043b9a7d78c1b3ff0083f72adc0556cbee8edf9afc13ba510af1b45a7a0f4cc813380e25cb98e699d22d79e603b92ab587badda5d1edb6aa7c58efa23726f071e22a4319f6d303370",
+    "kdf": "scrypt",
+    "cipherparams": { "iv": "3081c9838a2bf0f47ffab13e511f8988" },
+    "cipher": "aes-128-ctr"
   }
 }


### PR DESCRIPTION
-  cannot migrate old private key ios eos keystore