### PR TITLE
chore: return eth address add checksum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4303,6 +4303,7 @@ dependencies = [
  "base58",
  "base64 0.13.1",
  "bytes",
+ "ethereum-types",
  "hex",
  "lazy_static",
  "libc",

--- a/imkey-core/ikc/src/handler.rs
+++ b/imkey-core/ikc/src/handler.rs
@@ -209,25 +209,15 @@ pub(crate) fn get_extended_public_keys(data: &[u8]) -> Result<Vec<u8>> {
         let extended_public_key = match public_key_derivation.chain_type.as_str() {
             "BITCOIN" | "LITCOIN" | "BITCOINCASH" => {
                 BtcAddress::get_xpub(Network::Bitcoin, public_key_derivation.path.as_str())?
-            },
-            "ETHEREUM" => {
-                EthAddress::get_xpub(public_key_derivation.path.as_str())?
-            },
-            "COSMOS" => {
-                CosmosAddress::get_xpub(public_key_derivation.path.as_str())?
-            },
+            }
+            "ETHEREUM" => EthAddress::get_xpub(public_key_derivation.path.as_str())?,
+            "COSMOS" => CosmosAddress::get_xpub(public_key_derivation.path.as_str())?,
             "FILECOIN" => {
                 FilecoinAddress::get_xpub("MAINNET", public_key_derivation.path.as_str())?
-            },
-            "TRON" => {
-                TronAddress::get_xpub(public_key_derivation.path.as_str())?
-            },
-            "EOS" => {
-                EosPubkey::get_xpub(public_key_derivation.path.as_str())?
-            },
-            "NERVOS" => {
-                CkbAddress::get_xpub("MAINNET", public_key_derivation.path.as_str())?
-            },
+            }
+            "TRON" => TronAddress::get_xpub(public_key_derivation.path.as_str())?,
+            "EOS" => EosPubkey::get_xpub(public_key_derivation.path.as_str())?,
+            "NERVOS" => CkbAddress::get_xpub("MAINNET", public_key_derivation.path.as_str())?,
             _ => return Err(anyhow!("unsupported_chain_type")),
         };
         extended_public_keys.push(extended_public_key);

--- a/imkey-core/ikc/src/lib.rs
+++ b/imkey-core/ikc/src/lib.rs
@@ -1752,11 +1752,4 @@ mod tests {
             assert_eq!("success", bind_result.bind_status);
         }
     }
-
-    #[test]
-    fn test1(){
-        let req_hex = "1218696d6b65795f636f6d6d616e645f646174615f6572726f72";
-        let res = ErrorResponse::decode(hex::decode(req_hex).unwrap().as_slice()).unwrap();
-        println!("{:?}",res);
-    }
 }

--- a/token-core/tcx/Cargo.toml
+++ b/token-core/tcx/Cargo.toml
@@ -38,7 +38,7 @@ hex = "=0.4.3"
 base64 = "=0.13.1"
 base58 = "=0.2.0"
 parking_lot = "=0.12.1"
-
+ethereum-types = "=0.14.0"
 strum = { version = "=0.25.0", features = ["derive"] }
 
 [lib]


### PR DESCRIPTION
- Add checksum to the eth address returned by the scan_legacy_keystores interface
- Modify related test cases