### PR TITLE
fix: assert overwrite wallet first

### DIFF
--- a/token-core/tcx/src/handler.rs
+++ b/token-core/tcx/src/handler.rs
@@ -145,29 +145,28 @@ fn import_private_key_internal(
     original: Option<String>,
 ) -> Result<ImportPrivateKeyResult> {
     let overwrite_id = param.overwrite_id.to_string();
-    let mut founded_id: Option<String> = None;
+    assert_seed_equals(&overwrite_id, &param.private_key, false)?;
+    let mut target_id: Option<String> = None;
     {
         let fingerprint = fingerprint_from_any_format_pk(&param.private_key)?;
         let map = KEYSTORE_MAP.read();
-        if let Some(founded) = map
-            .values()
-            .find(|keystore| keystore.fingerprint() == fingerprint)
-        {
-            founded_id = Some(founded.id());
+        if let Some(founded) = map.values().find(|keystore| {
+            keystore.fingerprint() == fingerprint && keystore.id() != overwrite_id.to_string()
+        }) {
+            target_id = Some(founded.id());
         }
     }
 
-    if founded_id.is_some() && Some(overwrite_id.to_string()) != founded_id {
+    if target_id.is_some() {
         return Ok(crate::api::ImportPrivateKeyResult {
             is_existed: true,
-            existed_id: founded_id.unwrap().to_string(),
+            existed_id: target_id.unwrap().to_string(),
             ..Default::default()
         });
     }
 
     if !overwrite_id.is_empty() {
-        assert_seed_equals(&overwrite_id, &param.private_key, false)?;
-        founded_id = Some(overwrite_id);
+        target_id = Some(overwrite_id);
     }
 
     let decoded_ret = decode_private_key(&param.private_key)?;
@@ -212,7 +211,7 @@ fn import_private_key_internal(
 
     let mut keystore = Keystore::PrivateKey(pk_store);
 
-    if let Some(exist_kid) = founded_id {
+    if let Some(exist_kid) = target_id {
         keystore.set_id(&exist_kid)
     }
 
@@ -527,23 +526,22 @@ pub fn create_keystore(data: &[u8]) -> Result<Vec<u8>> {
 pub fn import_mnemonic(data: &[u8]) -> Result<Vec<u8>> {
     let param: ImportMnemonicParam =
         ImportMnemonicParam::decode(data).expect("import_mnemonic param");
-
-    let mut founded_id: Option<String> = None;
+    assert_seed_equals(param.overwrite_id.as_str(), &param.mnemonic, true)?;
+    let mut target_id: Option<String> = None;
     {
         let fingerprint = fingerprint_from_mnemonic(&param.mnemonic)?;
         let map = KEYSTORE_MAP.read();
-        if let Some(founded) = map
-            .values()
-            .find(|keystore| keystore.fingerprint() == fingerprint)
-        {
-            founded_id = Some(founded.id());
+        if let Some(founded) = map.values().find(|keystore| {
+            keystore.fingerprint() == fingerprint && keystore.id() != param.overwrite_id.to_string()
+        }) {
+            target_id = Some(founded.id());
         }
     }
 
-    if founded_id.is_some() && Some(param.overwrite_id.to_string()) != founded_id {
+    if target_id.is_some() {
         let result = KeystoreResult {
             is_existed: true,
-            existed_id: founded_id.unwrap().to_string(),
+            existed_id: target_id.unwrap().to_string(),
             ..Default::default()
         };
         let ret = encode_message(result)?;
@@ -551,8 +549,7 @@ pub fn import_mnemonic(data: &[u8]) -> Result<Vec<u8>> {
     }
 
     if !param.overwrite_id.is_empty() {
-        assert_seed_equals(param.overwrite_id.as_str(), &param.mnemonic, true)?;
-        founded_id = Some(param.overwrite_id);
+        target_id = Some(param.overwrite_id);
     }
 
     let meta = Metadata {
@@ -566,7 +563,7 @@ pub fn import_mnemonic(data: &[u8]) -> Result<Vec<u8>> {
 
     let mut keystore = Keystore::Hd(ks);
 
-    if let Some(id) = founded_id {
+    if let Some(id) = target_id {
         keystore.set_id(&id);
     }
 

--- a/token-core/tcx/tests/import_test.rs
+++ b/token-core/tcx/tests/import_test.rs
@@ -1515,6 +1515,48 @@ pub fn test_reset_password_private_seed_already_exist() {
 
 #[test]
 #[serial]
+pub fn test_reset_password_private_seed_valid_first() {
+    run_test(|| {
+        let import_param = ImportPrivateKeyParam {
+            private_key: TEST_WIF.to_string(),
+            password: "new_password".to_string(),
+            network: "TESTNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: "".to_string(),
+        };
+
+        let ret = call_api("import_private_key", import_param).unwrap();
+        let import_wallet_a_result: ImportPrivateKeyResult =
+            ImportPrivateKeyResult::decode(ret.as_slice()).unwrap();
+        let import_param = ImportPrivateKeyParam {
+            private_key: TEST_PRIVATE_KEY.to_string(),
+            password: "new_password".to_string(),
+            network: "MAINNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: "".to_string(),
+        };
+
+        let ret = call_api("import_private_key", import_param).unwrap();
+        let import_private_key_b_result = ImportPrivateKeyResult::decode(ret.as_slice()).unwrap();
+
+        let import_param = ImportPrivateKeyParam {
+            private_key: TEST_WIF.to_string(),
+            password: "new_password".to_string(),
+            network: "MAINNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: import_private_key_b_result.id.to_string(),
+        };
+
+        let ret = call_api("import_private_key", import_param);
+        assert_eq!(format!("{}", ret.err().unwrap()), "seed_not_equals");
+    })
+}
+
+#[test]
+#[serial]
 pub fn test_reset_password_hd_seed_already_exist() {
     run_test(|| {
         let import_param = ImportMnemonicParam {
@@ -1543,6 +1585,50 @@ pub fn test_reset_password_hd_seed_already_exist() {
         let import_mnemonic_result = KeystoreResult::decode(ret.as_slice()).unwrap();
         assert_eq!(import_mnemonic_result.existed_id, import_result.id);
         assert!(import_mnemonic_result.is_existed);
+    })
+}
+
+#[test]
+#[serial]
+pub fn test_reset_password_hd_valid_overwrite_wallet_first() {
+    run_test(|| {
+        let import_param = ImportMnemonicParam {
+            mnemonic: TEST_MNEMONIC.to_string(),
+            password: "new_password".to_string(),
+            network: "TESTNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: "".to_string(),
+        };
+
+        let ret = call_api("import_mnemonic", import_param).unwrap();
+        let import_wallet_a_result: KeystoreResult =
+            KeystoreResult::decode(ret.as_slice()).unwrap();
+        assert_eq!(import_wallet_a_result.is_existed, false);
+        assert_eq!(import_wallet_a_result.existed_id, "".to_string());
+        let import_param = ImportMnemonicParam {
+            mnemonic: OTHER_MNEMONIC.to_string(),
+            password: "new_password".to_string(),
+            network: "MAINNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: "".to_string(),
+        };
+
+        let ret = call_api("import_mnemonic", import_param).unwrap();
+        let import_wallet_b_result = KeystoreResult::decode(ret.as_slice()).unwrap();
+
+        let import_param = ImportMnemonicParam {
+            mnemonic: TEST_MNEMONIC.to_string(),
+            password: "new_password".to_string(),
+            network: "MAINNET".to_string(),
+            name: "reset_password".to_string(),
+            password_hint: "".to_string(),
+            overwrite_id: import_wallet_b_result.id.to_string(),
+        };
+
+        let ret = call_api("import_mnemonic", import_param);
+        assert_eq!(format!("{}", ret.err().unwrap()), "seed_not_equals");
     })
 }
 


### PR DESCRIPTION
## Summary of Changes
- assert the target wallet before search existed wallet

https://imtoken.atlassian.net/browse/R2D2-11396

<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
