### PR TITLE
fix: remove bech32_prefix from ikc

### DIFF
--- a/imkey-core/ikc-proto/src/api.proto
+++ b/imkey-core/ikc-proto/src/api.proto
@@ -109,7 +109,6 @@ message DeriveAccountsParam {
         string segWit = 4;
         string chainId = 5;
         string curve = 6;
-        string bech32Prefix = 7;
     }
     repeated Derivation derivations= 1;
 }

--- a/imkey-core/ikc/src/api.rs
+++ b/imkey-core/ikc/src/api.rs
@@ -181,8 +181,6 @@ pub mod derive_accounts_param {
         pub chain_id: ::prost::alloc::string::String,
         #[prost(string, tag = "6")]
         pub curve: ::prost::alloc::string::String,
-        #[prost(string, tag = "7")]
-        pub bech32_prefix: ::prost::alloc::string::String,
     }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/imkey-core/ikc/src/handler.rs
+++ b/imkey-core/ikc/src/handler.rs
@@ -358,7 +358,6 @@ mod test {
             seg_wit: "".to_string(),
             chain_id: "".to_string(),
             curve: "ed25519".to_string(),
-            bech32_prefix: "".to_string(),
         }];
         let param = DeriveAccountsParam { derivations };
         let response = derive_accounts(&encode_message(param).unwrap());

--- a/imkey-core/ikc/src/lib.rs
+++ b/imkey-core/ikc/src/lib.rs
@@ -344,7 +344,6 @@ mod tests {
                 seg_wit: "NONE".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "LITECOIN".to_string(),
@@ -353,7 +352,6 @@ mod tests {
                 seg_wit: "P2WPKH".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "LITECOIN".to_string(),
@@ -362,7 +360,6 @@ mod tests {
                 seg_wit: "NONE".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "TRON".to_string(),
@@ -371,7 +368,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "NERVOS".to_string(),
@@ -380,7 +376,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "FILECOIN".to_string(),
@@ -389,7 +384,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "COSMOS".to_string(),
@@ -398,7 +392,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "EOS".to_string(),
@@ -407,7 +400,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "ETHEREUM".to_string(),
@@ -416,7 +408,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -425,7 +416,6 @@ mod tests {
                 seg_wit: "NONE".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -434,7 +424,6 @@ mod tests {
                 seg_wit: "P2WPKH".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "KUSAMA".to_string(),
@@ -443,7 +432,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "ed25519".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "POLKADOT".to_string(),
@@ -452,7 +440,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "ed25519".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOINCASH".to_string(),
@@ -461,7 +448,6 @@ mod tests {
                 seg_wit: "NONE".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "NERVOS".to_string(),
@@ -470,7 +456,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "FILECOIN".to_string(),
@@ -479,7 +464,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -488,7 +472,6 @@ mod tests {
                 seg_wit: "NONE".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -497,7 +480,6 @@ mod tests {
                 seg_wit: "P2WPKH".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "COSMOS".to_string(),
@@ -506,7 +488,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "EOS".to_string(),
@@ -515,7 +496,6 @@ mod tests {
                 seg_wit: "".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -524,7 +504,6 @@ mod tests {
                 seg_wit: "VERSION_0".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -533,7 +512,6 @@ mod tests {
                 seg_wit: "VERSION_1".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -542,7 +520,6 @@ mod tests {
                 seg_wit: "VERSION_0".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
             Derivation {
                 chain_type: "BITCOIN".to_string(),
@@ -551,7 +528,6 @@ mod tests {
                 seg_wit: "VERSION_1".to_string(),
                 chain_id: "".to_string(),
                 curve: "secp256k1".to_string(),
-                bech32_prefix: "".to_string(),
             },
         ];
         let param = DeriveAccountsParam { derivations };
@@ -840,7 +816,6 @@ mod tests {
             seg_wit: "".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation.clone());
         let mut derive_sub_accounts_param = DeriveSubAccountsParam {
@@ -921,7 +896,6 @@ mod tests {
             seg_wit: "NONE".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation.clone());
         let mut derive_sub_accounts_param = DeriveSubAccountsParam {
@@ -1097,7 +1071,6 @@ mod tests {
             seg_wit: "".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation);
         let derive_sub_accounts_param = DeriveSubAccountsParam {
@@ -1146,7 +1119,6 @@ mod tests {
             seg_wit: "".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation.clone());
         let mut derive_sub_accounts_param = DeriveSubAccountsParam {
@@ -1228,7 +1200,6 @@ mod tests {
             seg_wit: "".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation.clone());
         let mut derive_sub_accounts_param = DeriveSubAccountsParam {
@@ -1309,7 +1280,6 @@ mod tests {
             seg_wit: "NONE".to_string(),
             chain_id: "".to_string(),
             curve: "secp256k1".to_string(),
-            bech32_prefix: "".to_string(),
         };
         let derived_accounts_result = derive_account(derivation.clone());
         let mut derive_sub_accounts_param = DeriveSubAccountsParam {


### PR DESCRIPTION
## Summary of Changes
- remove unused bech32Prefix param

<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
