### PR TITLE
chore: ikc add upgrade_applet error info[OPS-3225]

### DIFF
--- a/.github/workflows/build-release-android.yml
+++ b/.github/workflows/build-release-android.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 5
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/build-release-ios.yml
+++ b/.github/workflows/build-release-ios.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 5
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/run-unittest.yml
+++ b/.github/workflows/run-unittest.yml
@@ -40,7 +40,7 @@ jobs:
           fetch-depth: 5
 
       - name: Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/registry

--- a/imkey-core/ikc-common/src/apdu.rs
+++ b/imkey-core/ikc-common/src/apdu.rs
@@ -657,7 +657,7 @@ impl ApduCheck {
             "F080" => Err(ApduError::ImkeyInMenuPage.into()),
             "F081" => Err(ApduError::ImkeyPinNotVerified.into()),
             "6F01" => Err(ApduError::ImkeyBluetoothChannelError.into()),
-            "6943" => Err(ApduError::ImkeyMnemonicCheckFail.into()),
+            "6943" => Err(ApduError::ImkeyMnemonicCheckFailed.into()),
             _ => Err(anyhow!("imkey_command_execute_fail_{}", response_data)), //Err(ApduError::ImkeyCommandExecuteFail.into())
         }
     }

--- a/imkey-core/ikc-common/src/constants.rs
+++ b/imkey-core/ikc-common/src/constants.rs
@@ -1,6 +1,6 @@
 pub const VERSION: &str = "2.16.0";
-pub const URL: &str = "https://imkey.online:1000/imkey";
-// pub const URL: &str = "https://imkeyserver.com:10444/imkey";
+// pub const URL: &str = "https://imkey.online:1000/imkey";
+pub const URL: &str = "https://imkeyserver.com:10444/imkey";
 
 pub const TSM_ACTION_SE_SECURE_CHECK: &str = "/seSecureCheck";
 pub const TSM_ACTION_APP_DOWNLOAD: &str = "/appDownload";

--- a/imkey-core/ikc-common/src/constants.rs
+++ b/imkey-core/ikc-common/src/constants.rs
@@ -1,6 +1,6 @@
-pub const VERSION: &str = "2.16.0";
-// pub const URL: &str = "https://imkey.online:1000/imkey";
-pub const URL: &str = "https://imkeyserver.com:10444/imkey";
+pub const VERSION: &str = "2.16.4";
+pub const URL: &str = "https://imkey.online:1000/imkey";
+// pub const URL: &str = "https://imkeyserver.com:10444/imkey";
 
 pub const TSM_ACTION_SE_SECURE_CHECK: &str = "/seSecureCheck";
 pub const TSM_ACTION_APP_DOWNLOAD: &str = "/appDownload";

--- a/imkey-core/ikc-common/src/error.rs
+++ b/imkey-core/ikc-common/src/error.rs
@@ -10,6 +10,8 @@ pub enum CommonError {
     InvalidBase58,
     #[error("missing_network")]
     MissingNetwork,
+    #[error("upgrade_applet")]
+    UpgradeApplet,
 }
 
 #[derive(Error, Debug, PartialOrd, PartialEq)]
@@ -42,8 +44,8 @@ pub enum ApduError {
     ImkeyInMenuPage,
     #[error("imkey_pin_not_verified")]
     ImkeyPinNotVerified,
-    #[error("imkey_mnemonic_check_fail")]
-    ImkeyMnemonicCheckFail,
+    #[error("imkey_mnemonic_check_failed")]
+    ImkeyMnemonicCheckFailed,
 }
 
 #[derive(Error, Debug, PartialOrd, PartialEq)]

--- a/imkey-core/ikc-wallet/coin-bitcoin/src/transaction.rs
+++ b/imkey-core/ikc-wallet/coin-bitcoin/src/transaction.rs
@@ -140,7 +140,7 @@ impl BtcTransaction {
                     self.sign_p2pkh_inputs(&utxo_pub_key_vec, &mut tx_to_sign)?;
                 }
             } else {
-                return Err(CoinError::InvalidAddress.into());
+                return Err(CommonError::UpgradeApplet.into());
             }
         }
 

--- a/imkey-core/ikc-wallet/coin-bitcoin/src/transaction.rs
+++ b/imkey-core/ikc-wallet/coin-bitcoin/src/transaction.rs
@@ -120,7 +120,7 @@ impl BtcTransaction {
             for utxo in self.unspents.iter() {
                 let script = Script::from_str(&utxo.script_pubkey)?;
                 if !script.is_p2pkh() && !script.is_p2sh() {
-                    return Err(CoinError::InvalidUtxo.into());
+                    return Err(CommonError::UpgradeApplet.into());
                 }
             }
             let address_version =


### PR DESCRIPTION
## Summary of Changes
 ikc add upgrade_applet error info
<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
