### PR TITLE
chore: optimize the error prompt of importing private key[R2D2-14129]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4339,6 +4339,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "schnorrkel",
  "serde",
  "serde_json",
  "serial_test",

--- a/token-core/tcx/Cargo.toml
+++ b/token-core/tcx/Cargo.toml
@@ -41,6 +41,8 @@ base58 = "=0.2.0"
 parking_lot = "=0.12.1"
 ethereum-types = "=0.14.0"
 strum = { version = "=0.25.0", features = ["derive"] }
+sp-core = "=7.0.0"
+schnorrkel = "=0.9.1"
 
 [lib]
 name = "tcx"

--- a/token-core/tcx/src/handler.rs
+++ b/token-core/tcx/src/handler.rs
@@ -272,10 +272,14 @@ pub(crate) fn decode_private_key(private_key: &str) -> Result<DecodedPrivateKey>
                 curve = CurveType::SECP256k1;
             } else if decoded_data.len() == 64 {
                 let sr25519_key = Sr25519PrivateKey::from_slice(&decoded_data)?;
+                //Originally, the to_bytes method of Sr25519 PrivateKey was called for conversion, but to_bytes did not return Result Trait.
+                //In order to return the "invalid_private_key" error code, the code of the to_bytes method was directly copied for conversion.[R2D2-14129]
+                // private_key_bytes = sr25519_key.to_bytes();
                 let bytes = sr25519_key.0.to_raw_vec();
                 let secret_key =
                     SecretKey::from_bytes(&bytes).map_err(|_| anyhow!("invalid_private_key"))?;
                 private_key_bytes = secret_key.to_ed25519_bytes().to_vec();
+
                 chain_types.push("KUSAMA".to_string());
                 chain_types.push("POLKADOT".to_string());
                 curve = CurveType::SR25519;

--- a/token-core/tcx/tests/import_test.rs
+++ b/token-core/tcx/tests/import_test.rs
@@ -1782,3 +1782,22 @@ fn delete_dir_contents(path: &str) {
         }
     };
 }
+
+#[test]
+#[serial]
+pub fn test_import_invalid_private_key() {
+    run_test(|| {
+        let param: ImportPrivateKeyParam = ImportPrivateKeyParam {
+            private_key: "19e2ee93266b2d9bb72130afa34abcc5ce44790c9a9bdc78aed829e076175ec0eef295f3b5918187fc9f65f1cd3db0a06051582128af45aaf54a10d38ff56d29"
+                .to_string(),
+            password: TEST_PASSWORD.to_string(),
+            name: "test_import_invalid_private".to_string(),
+            password_hint: "".to_string(),
+            network: "".to_string(),
+            overwrite_id: "".to_string(),
+        };
+
+        let ret = import_private_key(&encode_message(param).unwrap());
+        assert_eq!(ret.err().unwrap().to_string(), "invalid_private_key");
+    })
+}


### PR DESCRIPTION
## Summary of Changes
optimize the error prompt of importing private key[R2D2-14129]
<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
