### PR TITLE
ci: Add GPG public key info and user mentions to Android build Slack notifications

### DIFF
--- a/.github/workflows/build-release-android.yml
+++ b/.github/workflows/build-release-android.yml
@@ -150,6 +150,11 @@ jobs:
             ${{github.workspace}}/publish/android/build/jreleaser/trace.log
             ${{github.workspace}}/publish/android/build/jreleaser/output.properties
 
+      - name: Get GPG key first line
+        id: gpg_info
+        run: |
+          echo "gpg_first_line=$(echo '${{ secrets.GPG_PUBLIC_KEY }}' | sed -n '3p')" >> $GITHUB_OUTPUT
+
       - name: Send custom JSON data to Slack workflow
         id: slack
         uses: slackapi/slack-github-action@v1.23.0
@@ -157,13 +162,13 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}",
+              "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key First Line: ${{ steps.gpg_info.outputs.gpg_first_line }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@xiaoguang Please review the build results.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}"
+                    "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key First Line: ${{ steps.gpg_info.outputs.gpg_first_line }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@xiaoguang Please review the build results."
                   }
                 }
               ]

--- a/.github/workflows/build-release-android.yml
+++ b/.github/workflows/build-release-android.yml
@@ -150,10 +150,10 @@ jobs:
             ${{github.workspace}}/publish/android/build/jreleaser/trace.log
             ${{github.workspace}}/publish/android/build/jreleaser/output.properties
 
-      - name: Get GPG key first line
+      - name: Get GPG key SHA256 hash
         id: gpg_info
         run: |
-          echo "gpg_first_line=$(echo '${{ secrets.GPG_PUBLIC_KEY }}' | sed -n '3p')" >> $GITHUB_OUTPUT
+          echo "gpg_sha256=$(echo '${{ secrets.GPG_PUBLIC_KEY }}' | shasum -a 256 | awk '{print $1}')" >> $GITHUB_OUTPUT
 
       - name: Send custom JSON data to Slack workflow
         id: slack
@@ -162,13 +162,13 @@ jobs:
           # For posting a rich message using Block Kit
           payload: |
             {
-              "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key First Line: ${{ steps.gpg_info.outputs.gpg_first_line }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@xiaoguang Please review the build results.",
+              "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key SHA256: ${{ steps.gpg_info.outputs.gpg_sha256 }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@Brian Shi @xyz @xiaoguang Please review the build results.",
               "blocks": [
                 {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key First Line: ${{ steps.gpg_info.outputs.gpg_first_line }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@xiaoguang Please review the build results."
+                    "text": "New build of android-token-core: ${{ job.status }}\nVERSION: ${{ steps.getversion.outputs.version }}\nTokenCore Sha256: ${{ steps.build.outputs.tokencore_sha256 }}\nGPG Key SHA256: ${{ steps.gpg_info.outputs.gpg_sha256 }}\nCheck more: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}\nCommits:\n${{ steps.getcommits.outputs.commits }}\n@Brian Shi @xyz @xiaoguang Please review the build results."
                   }
                 }
               ]

--- a/publish/android/GPG_SETUP.md
+++ b/publish/android/GPG_SETUP.md
@@ -53,7 +53,7 @@
 
 确保您已经：
 
-1. 在Sonatype OSSRH (https://s01.oss.sonatype.org/) 注册了一个账号
+1. 在Sonatype OSSRH (https://central.sonatype.com/) 注册了一个账号
 2. 创建了一个项目/包的命名空间（例如：io.github.yourusername）
 3. 将以下信息添加为GitHub Secrets：
    - `OSSRH_USERNAME`: 您的Sonatype用户名


### PR DESCRIPTION
## Summary of Changes
Add GPG public key info and user mentions to Android build Slack notifications
<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
