### PR TITLE
ci: Cancel the compilation of the native secp256k1 library

### DIFF
--- a/script/build-android.sh
+++ b/script/build-android.sh
@@ -24,12 +24,12 @@ OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-arm/lib OPENSSL_INCLUDE_DIR=$OPENS
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86_64/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86_64/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
 
-pushd ../token-core/tcx-libs/secp256k1/
-AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/aarch64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target aarch64-linux-android --release
-AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/armv7a-linux-androideabi22-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target armv7-linux-androideabi --release
-AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
-AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
-popd
+# pushd ../token-core/tcx-libs/secp256k1/
+# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/aarch64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target aarch64-linux-android --release
+# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/armv7a-linux-androideabi22-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target armv7-linux-androideabi --release
+# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
+# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
+# popd
 
 # copy so to jinLibs
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/

--- a/script/build-android.sh
+++ b/script/build-android.sh
@@ -35,19 +35,19 @@ OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86_64/lib OPENSSL_INCLUDE_DIR=$OP
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 cp -rf ../target/aarch64-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 cp -rf ../target/aarch64-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
-cp -rf ../token-core/tcx-libs/secp256k1/target/aarch64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
+# cp -rf ../token-core/tcx-libs/secp256k1/target/aarch64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 cp -rf ../target/armv7-linux-androideabi/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 cp -rf ../target/armv7-linux-androideabi/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
-cp -rf ../token-core/tcx-libs/secp256k1/target/armv7-linux-androideabi/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
+# cp -rf ../token-core/tcx-libs/secp256k1/target/armv7-linux-androideabi/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86/
-cp -rf ../token-core/tcx-libs/secp256k1/target/i686-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86/
+# cp -rf ../token-core/tcx-libs/secp256k1/target/i686-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86_64/
 cp -rf ../target/x86_64-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
 cp -rf ../target/x86_64-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
-cp -rf ../token-core/tcx-libs/secp256k1/target/x86_64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
+# cp -rf ../token-core/tcx-libs/secp256k1/target/x86_64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86_64/

--- a/script/build-android.sh
+++ b/script/build-android.sh
@@ -24,30 +24,19 @@ OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-arm/lib OPENSSL_INCLUDE_DIR=$OPENS
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86_64/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86_64/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
 
-# pushd ../token-core/tcx-libs/secp256k1/
-# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/aarch64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target aarch64-linux-android --release
-# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/armv7a-linux-androideabi22-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target armv7-linux-androideabi --release
-# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
-# AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
-# popd
-
 # copy so to jinLibs
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 cp -rf ../target/aarch64-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 cp -rf ../target/aarch64-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
-# cp -rf ../token-core/tcx-libs/secp256k1/target/aarch64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/arm64-v8a/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 cp -rf ../target/armv7-linux-androideabi/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 cp -rf ../target/armv7-linux-androideabi/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
-# cp -rf ../token-core/tcx-libs/secp256k1/target/armv7-linux-androideabi/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/armeabi-v7a/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86/
-# cp -rf ../token-core/tcx-libs/secp256k1/target/i686-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86/
 
 mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86_64/
 cp -rf ../target/x86_64-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
 cp -rf ../target/x86_64-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
-# cp -rf ../token-core/tcx-libs/secp256k1/target/x86_64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86_64/


### PR DESCRIPTION
## Summary of Changes

<!--
  Required:
    - Enter a jira link for this PR.
-->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested? (Test Plan)

<!--
  Required:
    - Please describe in detail how you tested your changes.
    - Include details of your testing environment, and the tests you ran to
    - See how your change affects other areas of the code, etc. -
    - Any useful notes explaining how best to test and verify.
    - Bonus points for screenshots and videos!
-->

## Other information

<!-- Any useful information. -->

## Screenshots (if appropriate):

## Final checklist

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## Security checklist (only for leader check)

- [ ] No backdoor risk
  - Check for unknown network request urls, and script/shell files with unclear purposes,
  - The backend service cannot expose leaked data interfaces for various reasons (even for testing purposes)
- [ ] No network communication protocol risk
  - Check whether to introduce unsafe network calls such as http/ws
- [ ] No import potentially risk 3rd library
  - Check whether 3rd dependent library is import
  - Don't use an unknown third-party library
  - Check the 3rd library sources are fetched from normal sources, such as npm, gomodule, maven, cocoapod, Do not use unknown sources
  - Check github Dependabot alerts, Whether to add new issues
- [ ] Private data not exposed
  - Check whether there are exclusive ApiKey, privatekey and other private information uploaded to git
  - Check if the packaged keystore has been uploaded to git
