### PR TITLE
chore: removed the x86_64 building on android

### DIFF
--- a/script/build-android.sh
+++ b/script/build-android.sh
@@ -22,13 +22,11 @@ export OPENSSL_DIR=$GITHUB_WORKSPACE/imkey-core/ikc-depend/openssl
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-arm64/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-arm64/include  AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/aarch64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target aarch64-linux-android --release
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-arm/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-arm/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/armv7a-linux-androideabi22-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target armv7-linux-androideabi --release
 OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
-OPENSSL_LIB_DIR=$OPENSSL_LIB_ROOT_DIR/android-x86_64/lib OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_ROOT_DIR/android-x86_64/include AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
 
 pushd ../token-core/tcx-libs/secp256k1/
 AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/aarch64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target aarch64-linux-android --release
 AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/armv7a-linux-androideabi22-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target armv7-linux-androideabi --release
 AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/i686-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target i686-linux-android --release
-AR=$ANDROID_NDK_TOOLCHAINS/llvm-ar CC=$ANDROID_NDK_TOOLCHAINS/x86_64-linux-android29-clang LD=$ANDROID_NDK_TOOLCHAINS/ld env OPENSSL_STATIC=1 cargo build --target x86_64-linux-android --release
 popd
 
 # copy so to jinLibs
@@ -46,8 +44,3 @@ mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../target/i686-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86/
 cp -rf ../token-core/tcx-libs/secp256k1/target/i686-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86/
-
-mkdir -p ../publish/android/tokencore/src/main/jniLibs/x86_64/
-cp -rf ../target/x86_64-linux-android/release/libconnector.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
-cp -rf ../target/x86_64-linux-android/release/libtcx.so ../publish/android/tokencore/src/main/jniLibs/x86_64/
-cp -rf ../token-core/tcx-libs/secp256k1/target/x86_64-linux-android/release/libsecp256k1.so ../publish/android/tokencore/src/main/jniLibs/x86_64/


### PR DESCRIPTION
## Summary of Changes

What:
https://github.com/consenlabs/token-v2/issues/5485
解决 libtcx.so 和 libconnector.so 没有支持 16 KB 内存的问题

Why:
升级 macOS apple arm64 后 https://github.com/consenlabs/token-core-monorepo/blob/d262f6a2e5559f155d0b0327426ae396cd391ffe/script/build-android.sh#L25 打包执行到这一步会失败

因为 https://github.com/filecoin-project/fff/blob/b064b8de977c9fdf0ec90d255b7acc3a7e8dfe8b/build.rs#L1 被宏拦截了，之前是 macOS x86_64 不会做拦截，所以换成 macOS arm64 后在 https://github.com/filecoin-project/fff/blob/b064b8de977c9fdf0ec90d255b7acc3a7e8dfe8b/src/asm.rs#L5 在 android-x86_64 下会报错 

android x86_64 根本没有在 token-v2 中被使用   
https://github.com/consenlabs/token-v2/blob/0f962e9692c8a1945e5366cbebd53f1cac4b10b5/Makefile#L153  就算是模拟器现在都很少这个架构的了，所以可以直接取消 android x86_64 的打包，可以解决 libtcx.so 和 libconnector.so 没有支持 16 KB 内存的问题和 macOS 升级为 arm64 后的问题

 👤 Human-Written
