### PR TITLE
fix: guard against empty accounts panic in legacy keystore scan

### DIFF
--- a/token-core/tcx/src/handler.rs
+++ b/token-core/tcx/src/handler.rs
@@ -680,6 +680,9 @@ fn identify_legacy_keystore_chain_types(legacy_keystore: &LegacyKeystoreResult) 
         .iter()
         .map(|account| account.chain_type.clone())
         .collect();
+    if active_chain_types.is_empty() {
+        return vec![];
+    }
     match (
         legacy_keystore.source.as_str(),
         active_chain_types[0].as_str(),


### PR DESCRIPTION
## Summary

Fix `index out of bounds: the len is 0 but the index is 0` panic in `identify_legacy_keystore_chain_types()` when a legacy keystore has an empty `accounts` array.

**Sentry**: IMTOKEN-V2-287J6 (20K+ events, grouped with other TCX errors due to shared stack trace)

## Root Cause

`handler.rs:685` — `active_chain_types[0]` panics when `legacy_keystore.accounts` is empty:

```rust
match (
    legacy_keystore.source.as_str(),
    active_chain_types[0].as_str(),  // ← panics if accounts is empty
) { ... }
```

This happens when `parse_tcx_keystore()` reads a legacy keystore file where `activeAccounts` is `[]` (corrupted data, incomplete migration, or truncated keystore file).

## Fix

Add an early return before the match:

```rust
if active_chain_types.is_empty() {
    return vec![];
}
```

## Error Behavior Change

| Before | After |
|--------|-------|
| Rust panic → `index out of bounds` → uncaught JS exception | Returns `vec![]` → keystore included in scan with empty `identified_chain_types` → no error |

The `index out of bounds` error **disappears entirely** — it becomes a graceful no-op. The keystore is still scanned and returned, just without chain type identification. This matches the existing behavior of the `(NEW_IDENTITY | RECOVERED_IDENTITY | MNEMONIC, _) => vec![]` branch.

## Regression Risk

**极低**:
- Only adds a 3-line guard before existing logic
- The empty-accounts case previously panicked (crash), now it returns empty (no-op)
- Normal keystores with non-empty accounts are completely unaffected — the guard is skipped
- `get_legacy_keystore()` caller already handles empty `identified_chain_types` correctly
- `from_ss58check_with_version` at line 303 always returns `vec![data[0]]` (1 element), so the other `[0]` index site cannot panic

## AI 参与度

- [ ] 🤖 AI-Generated
- [x] 🤝 AI-Assisted
- [ ] 👤 Human-Written