### PR TITLE
补充 tcx-wasm TypedData 签名说明并同步 WASM 文档

### DIFF
--- a/examples/wasm/README.md
+++ b/examples/wasm/README.md
@@ -509,6 +509,25 @@ const results = JSON.parse(sign_txs(JSON.stringify({
 
 Signs a message. Supports ETH PersonalSign / EcSign, TRON message, BTC-kin BIP-322 signing (BTC / BCH / LTC / DOGE), and EOS canonical signing.
 
+#### ETH Typed Data / EIP-712 warning
+
+`sign_message` does not accept structured Typed Data and does not run the EIP-712 `hashDomain` / `hashStruct` flow. For ETH `signatureType: "EcSign"`, `tcx-wasm` converts `input.message` to bytes and applies `keccak256` before signing.
+
+Do not pass `viem.hashTypedData(...)` or another SDK's final EIP-712 digest into `sign_message`; that digest has already been produced from `hashDomain` and `hashStruct`, so `tcx-wasm` will hash it again.
+
+AI / Vibe Coding guardrail:
+
+```ts
+// Avoid: this double-hashes the EIP-712 digest.
+const digest = hashTypedData({ domain, types, primaryType, message });
+sign_message(JSON.stringify({
+  chain: "ETHEREUM",
+  input: { message: digest, signatureType: "EcSign" },
+}));
+```
+
+Use or add a dedicated Typed Data signing API if EIP-712-compatible signatures are required.
+
 #### ETH PersonalSign
 
 ```ts

--- a/token-core/tcx-wasm/README.md
+++ b/token-core/tcx-wasm/README.md
@@ -197,6 +197,34 @@ Signs messages for:
   signing.
 - `EOS`: EOS message signing.
 
+#### ETH Typed Data / EIP-712 warning
+
+`sign_message` does not accept structured Typed Data and does not run the
+EIP-712 `hashDomain` / `hashStruct` flow. For `ETHEREUM` with
+`signatureType: "EcSign"`, `tcx-wasm` converts `input.message` to bytes and
+then applies `keccak256` before signing.
+
+Do not pass the result of SDK helpers such as `viem.hashTypedData(...)` into
+`sign_message`. `viem.hashTypedData(...)` already returns the final EIP-712
+digest after `hashDomain` and `hashStruct`; passing that digest to
+`sign_message` makes `tcx-wasm` hash the digest again and produces a signature
+that will not match normal EIP-712 verification.
+
+AI / Vibe Coding guardrail:
+
+```ts
+// Avoid: this double-hashes the EIP-712 digest.
+const digest = hashTypedData({ domain, types, primaryType, message });
+sign_message(JSON.stringify({
+  chain: "ETHEREUM",
+  input: { message: digest, signatureType: "EcSign" },
+}));
+```
+
+If you need EIP-712-compatible Typed Data signatures, use or add a dedicated
+Typed Data signing API that performs `hashDomain` / `hashStruct` exactly once
+and signs the resulting digest without hashing it again.
+
 ### `sign_psbt(paramJson)` and `sign_psbts(paramJson)`
 
 Signs one or more BTC-family PSBTs. `derivationPath` may be an account-level

--- a/token-core/tcx-wasm/README.zh-CN.md
+++ b/token-core/tcx-wasm/README.zh-CN.md
@@ -193,6 +193,33 @@ const result = JSON.parse(sign_tx(JSON.stringify({
 - `BITCOIN`、`BITCOINCASH`、`LITECOIN` 和 `DOGECOIN`：BIP-322 风格的消息签名。
 - `EOS`：EOS message signing。
 
+#### ETH Typed Data / EIP-712 注意事项
+
+`sign_message` 不接收结构化 Typed Data，也不会执行 EIP-712 的
+`hashDomain` / `hashStruct` 流程。`ETHEREUM` 使用
+`signatureType: "EcSign"` 时，`tcx-wasm` 会先将 `input.message` 转成字节，
+然后再做一次 `keccak256` 并签名。
+
+不要把 `viem.hashTypedData(...)` 等 SDK helper 的返回值直接传给
+`sign_message`。`viem.hashTypedData(...)` 已经执行了 `hashDomain` 和
+`hashStruct`，返回的是最终 EIP-712 digest；再传给 `sign_message` 会被
+`tcx-wasm` 再 hash 一次，生成的签名无法通过常规 EIP-712 校验。
+
+AI / Vibe Coding 防误用规则：
+
+```ts
+// 避免：这会对 EIP-712 digest 重复 hash。
+const digest = hashTypedData({ domain, types, primaryType, message });
+sign_message(JSON.stringify({
+  chain: "ETHEREUM",
+  input: { message: digest, signatureType: "EcSign" },
+}));
+```
+
+如果需要兼容 EIP-712 的 Typed Data 签名，请使用或新增专用的 Typed Data
+签名 API：只执行一次 `hashDomain` / `hashStruct`，并且对最终 digest 直接签名，
+不要再次 hash。
+
 ### `sign_psbt(paramJson)` 和 `sign_psbts(paramJson)`
 
 签名单个或多个 BTC 系 PSBT。`derivationPath` 可以是账户级路径；传入完整地址路径时，
@@ -249,4 +276,3 @@ event，也就是 `kind: 1059` 的事件。
 
 参考 [`examples/wasm`](../../examples/wasm)。该 Next.js 浏览器集成示例覆盖
 keystore 创建、账户派生、交易签名、消息签名、PSBT 签名和 Message API。
-


### PR DESCRIPTION
## Summary
- 补充 `tcx-wasm` 的消息签名说明，明确 `ETHEREUM` 的 `EcSign` 会在内部对 `input.message` 做 `keccak256`
- 说明 `sign_message` 不执行 EIP-712 的 `hashDomain` / `hashStruct` 流程，避免将 `viem.hashTypedData(...)` 的结果重复传入导致二次哈希
- 同步更新中英文 `tcx-wasm` README 以及 `examples/wasm` 文档，加入面向 AI / Vibe Coding 的误用提示
- 顺带更新 WASM API 相关说明与示例文档，保持实现与文档一致

## Testing
- Not run (not requested)
- 已进行文档差异检查，确认新增说明位置和 Markdown 结构正常