### PR TITLE
开源质量改进阶段五：安全敏感接口收敛

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5274,6 +5286,7 @@ name = "tcx-crypto"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "argon2",
  "bitcoin_hashes 0.20.0",
  "digest 0.11.3",
  "hex",

--- a/token-core/README.md
+++ b/token-core/README.md
@@ -50,12 +50,13 @@ Every time you will try to commit, pre-commit will run checks on your files to m
 and they aren't affected by some simple issues. If the checks fail, pre-commit won't let you commit.
 
 ## Read More
-* [How to build project](docs/BUILD.md)
-* [Crypto keys abstraction design (Chinese)](docs/KEYS.zh.md)
-* [Architecture design (Chinese)](docs/TECH.zh.md)
-* [How to add more blockchain support](docs/INTEGRATION.md)
+* [How to build project](tcx-docs/BUILD.md)
+* [Crypto keys abstraction design (Chinese)](tcx-docs/KEYS.zh.md)
+* [Keystore KDF strategy (Chinese)](tcx-docs/KDF.zh.md)
+* [Architecture design (Chinese)](tcx-docs/TECH.zh.md)
+* [How to add more blockchain support](tcx-docs/INTEGRATION.md)
 * [Security](SECURITY.md) including the bug bounty program
-* [FAQ](docs/FAQ.md)
+* [FAQ](tcx-docs/FAQ.md)
 
 ## License
 Apache Licence v2.0

--- a/token-core/tcx-crypto/Cargo.toml
+++ b/token-core/tcx-crypto/Cargo.toml
@@ -19,6 +19,7 @@ sha2 = "=0.11.0"
 digest = "=0.11.3"
 hmac = "=0.13.0"
 pbkdf2 = "=0.13.0"
+argon2 = "=0.5.3"
 bitcoin_hashes = "=0.20.0"
 anyhow = { version = "=1.0.102", features = [] }
 secp256k1 = {version = "=0.31.1", features = ["rand", "recovery"] }

--- a/token-core/tcx-crypto/src/crypto.rs
+++ b/token-core/tcx-crypto/src/crypto.rs
@@ -1,11 +1,15 @@
 use crate::Error;
 use crate::Result;
+use argon2::{Algorithm, Argon2, Params, Version};
 use serde::{Deserialize, Serialize};
 use std::env;
 use tcx_common::{random_u8_16, random_u8_32, FromHex, ToHex};
 use tiny_keccak::Hasher;
 
 const CREDENTIAL_LEN: usize = 64usize;
+const ARGON2ID_MEMORY_COST_KIB: u32 = 19 * 1024;
+const ARGON2ID_TIME_COST: u32 = 2;
+const ARGON2ID_PARALLELISM: u32 = 1;
 
 pub type Credential = [u8; CREDENTIAL_LEN];
 
@@ -80,6 +84,62 @@ impl KdfParams for Pbkdf2Params {
         let salt_bytes: Vec<u8> = FromHex::from_hex(&self.salt).unwrap();
         pbkdf2::pbkdf2::<hmac::Hmac<sha2::Sha256>>(password, &salt_bytes, self.c, out)
             .expect("HMAC-SHA256 PBKDF2 should accept any output length");
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Argon2idParams {
+    memory_cost: u32,
+    time_cost: u32,
+    parallelism: u32,
+    dklen: u32,
+    salt: String,
+}
+
+impl Default for Argon2idParams {
+    fn default() -> Argon2idParams {
+        Argon2idParams {
+            memory_cost: ARGON2ID_MEMORY_COST_KIB,
+            time_cost: ARGON2ID_TIME_COST,
+            parallelism: ARGON2ID_PARALLELISM,
+            dklen: CREDENTIAL_LEN as u32,
+            salt: "".to_owned(),
+        }
+    }
+}
+
+impl KdfParams for Argon2idParams {
+    fn name(&self) -> &str {
+        "argon2id"
+    }
+
+    fn validate(&self) -> Result<()> {
+        if self.dklen == 0
+            || self.memory_cost == 0
+            || self.time_cost == 0
+            || self.parallelism == 0
+            || self.salt.is_empty()
+        {
+            Err(Error::KdfParamsInvalid.into())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn derive_key(&self, password: &[u8], out: &mut [u8]) {
+        let salt_bytes: Vec<u8> = FromHex::from_hex(&self.salt).unwrap();
+        let params = Params::new(
+            self.memory_cost,
+            self.time_cost,
+            self.parallelism,
+            Some(out.len()),
+        )
+        .expect("init argon2id params");
+
+        Argon2::new(Algorithm::Argon2id, Version::V0x13, params)
+            .hash_password_into(password, &salt_bytes, out)
+            .expect("can not execute argon2id");
     }
 }
 
@@ -258,12 +318,12 @@ impl Crypto {
     }
 
     pub fn new(password: &str, origin: &[u8]) -> Crypto {
-        let param = Pbkdf2Params {
+        let param = Argon2idParams {
             salt: random_u8_32().to_hex(),
-            ..Pbkdf2Params::default()
+            ..Argon2idParams::default()
         };
 
-        Self::new_with_kdf(password, origin, KdfType::Pbkdf2(param))
+        Self::new_with_kdf(password, origin, KdfType::Argon2id(param))
     }
 
     pub fn new_with_kdf(password: &str, plaintext: &[u8], kdf: KdfType) -> Crypto {
@@ -306,6 +366,7 @@ impl Crypto {
 
     fn derive_key(&self, password: &str) -> Result<Vec<u8>> {
         let mut derived_key: Credential = [0u8; CREDENTIAL_LEN];
+        self.kdf.validate()?;
         self.kdf.derive_key(password.as_bytes(), &mut derived_key);
 
         Ok(derived_key.to_vec())
@@ -337,6 +398,9 @@ impl Crypto {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "kdf", content = "kdfparams")]
 pub enum KdfType {
+    #[serde(rename = "argon2id")]
+    Argon2id(Argon2idParams),
+
     #[serde(rename = "pbkdf2")]
     Pbkdf2(Pbkdf2Params),
 
@@ -346,13 +410,14 @@ pub enum KdfType {
 
 impl Default for KdfType {
     fn default() -> Self {
-        KdfType::Pbkdf2(Pbkdf2Params::default())
+        KdfType::Argon2id(Argon2idParams::default())
     }
 }
 
 impl KdfParams for KdfType {
     fn name(&self) -> &str {
         match self {
+            KdfType::Argon2id(_) => "argon2id",
             KdfType::Pbkdf2(_) => "pbkdf2",
             KdfType::Scrypt(_) => "scrypt",
         }
@@ -360,12 +425,14 @@ impl KdfParams for KdfType {
 
     fn validate(&self) -> Result<()> {
         match self {
+            KdfType::Argon2id(argon2id) => argon2id.validate(),
             KdfType::Pbkdf2(pbkdf2) => pbkdf2.validate(),
             KdfType::Scrypt(scrypt) => scrypt.validate(),
         }
     }
     fn derive_key(&self, password: &[u8], out: &mut [u8]) {
         match self {
+            KdfType::Argon2id(argon2id) => argon2id.derive_key(password, out),
             KdfType::Pbkdf2(pbkdf2) => pbkdf2.derive_key(password, out),
             KdfType::Scrypt(scrypt) => scrypt.derive_key(password, out),
         }
@@ -376,6 +443,7 @@ impl KdfParams for KdfType {
 mod tests {
     use super::*;
     use std::str::FromStr;
+    use std::time::{Duration, Instant};
     use tcx_common::random_u8_64;
     use tcx_constants::TEST_PASSWORD;
 
@@ -418,12 +486,12 @@ mod tests {
         assert_ne!(crypto.mac, "");
         assert_ne!(crypto.cipherparams.iv, "");
         match &crypto.kdf {
-            KdfType::Pbkdf2(params) => {
+            KdfType::Argon2id(params) => {
                 assert_ne!(params.salt, "")
             }
-            _ => panic!("kdf type must be pbkdf2"),
+            _ => panic!("kdf type must be argon2id"),
         }
-        assert_eq!("pbkdf2", crypto.kdf.name());
+        assert_eq!("argon2id", crypto.kdf.name());
     }
 
     #[test]
@@ -447,6 +515,15 @@ mod tests {
 
     #[test]
     fn test_kdf_type() {
+        let params = Argon2idParams {
+            salt: random_u8_32().to_hex(),
+            ..Default::default()
+        };
+
+        let kdf_type = KdfType::Argon2id(params);
+        assert!(kdf_type.validate().is_ok());
+        assert_eq!(kdf_type.name(), "argon2id");
+
         let params = Pbkdf2Params {
             salt: random_u8_32().to_hex(),
             ..Default::default()
@@ -466,7 +543,7 @@ mod tests {
         assert_eq!(kdf_type.name(), "scrypt");
 
         let kdf_type = KdfType::default();
-        assert_eq!(kdf_type.name(), "pbkdf2");
+        assert_eq!(kdf_type.name(), "argon2id");
     }
 
     #[test]
@@ -527,6 +604,20 @@ mod tests {
 
     #[test]
     fn test_kdfparams_trait_validate() {
+        let err = Argon2idParams::default().validate().err().unwrap();
+        assert_eq!(
+            err.downcast::<crate::Error>().unwrap(),
+            Error::KdfParamsInvalid,
+        );
+
+        let params = Argon2idParams {
+            salt: "0x1234".to_owned(),
+            ..Default::default()
+        };
+
+        assert!(params.validate().is_ok());
+        assert_eq!(params.name(), "argon2id");
+
         let err = Pbkdf2Params::default().validate().err().unwrap();
         assert_eq!(
             err.downcast::<crate::Error>().unwrap(),
@@ -547,15 +638,15 @@ mod tests {
             Error::KdfParamsInvalid
         );
 
-        assert_eq!(*crate::KDF_ROUNDS.read() as u32, 262144);
+        assert_eq!(*crate::KDF_ROUNDS.read() as u32, 600000);
 
         if let Ok(v) = env::var("KDF_ROUNDS") {
             let env_kdf_rounds = u32::from_str(&v).unwrap();
             env::remove_var("KDF_ROUNDS");
-            assert_eq!(default_kdf_rounds(), 262144);
+            assert_eq!(default_kdf_rounds(), 600000);
             env::set_var("KDF_ROUNDS", env_kdf_rounds.to_string());
         } else {
-            assert_eq!(default_kdf_rounds(), 262144);
+            assert_eq!(default_kdf_rounds(), 600000);
         }
     }
 
@@ -577,6 +668,26 @@ mod tests {
     }
 
     #[test]
+    fn test_derive_key_argon2id() {
+        let mut param = Argon2idParams {
+            memory_cost: 32,
+            time_cost: 2,
+            parallelism: 1,
+            salt: "01020304010203040102030401020304".to_string(),
+            ..Default::default()
+        };
+        let mut derived_key = [0; CREDENTIAL_LEN];
+        param.derive_key(TEST_PASSWORD.as_bytes(), &mut derived_key);
+        let dk_hex = derived_key.to_hex();
+        assert_eq!("d588733f0b9f482908fd7a2f9d48d61c40b01df8016b2ee3b10a51296d7b4e873d0ae92772dd94cce9d1c2ddfbb97fb25b7a66208713313fc04479712086db30", dk_hex);
+        assert_eq!("argon2id", param.name());
+
+        assert!(param.validate().is_ok());
+        param.memory_cost = 0;
+        assert!(param.validate().is_err());
+    }
+
+    #[test]
     fn test_derive_key_scrypt() {
         let mut param = SCryptParams {
             n: 1024,
@@ -592,6 +703,55 @@ mod tests {
         assert!(param.validate().is_ok());
         param.n = 0;
         assert!(param.validate().is_err());
+    }
+
+    fn profile_kdf<F>(name: &str, mut f: F) -> Duration
+    where
+        F: FnMut(),
+    {
+        let start = Instant::now();
+        f();
+        let elapsed = start.elapsed();
+        eprintln!("{name}: {} ms", elapsed.as_millis());
+        elapsed
+    }
+
+    #[test]
+    #[ignore]
+    fn test_kdf_profile() {
+        let password = TEST_PASSWORD.as_bytes();
+        let salt = "01020304010203040102030401020304".to_string();
+        let mut derived_key = [0; CREDENTIAL_LEN];
+
+        let argon2id = Argon2idParams {
+            salt: salt.clone(),
+            ..Default::default()
+        };
+        let argon2id_elapsed = profile_kdf("argon2id m=19456KiB t=2 p=1", || {
+            argon2id.derive_key(password, &mut derived_key)
+        });
+
+        let scrypt = SCryptParams {
+            n: 1 << 17,
+            salt: salt.clone(),
+            ..Default::default()
+        };
+        let scrypt_elapsed = profile_kdf("scrypt n=2^17 r=8 p=1", || {
+            scrypt.derive_key(password, &mut derived_key)
+        });
+
+        let pbkdf2 = Pbkdf2Params {
+            c: 600000,
+            salt,
+            ..Default::default()
+        };
+        let pbkdf2_elapsed = profile_kdf("pbkdf2-hmac-sha256 c=600000", || {
+            pbkdf2.derive_key(password, &mut derived_key)
+        });
+
+        assert!(argon2id_elapsed.as_nanos() > 0);
+        assert!(scrypt_elapsed.as_nanos() > 0);
+        assert!(pbkdf2_elapsed.as_nanos() > 0);
     }
 
     #[test]

--- a/token-core/tcx-crypto/src/lib.rs
+++ b/token-core/tcx-crypto/src/lib.rs
@@ -2,7 +2,7 @@ pub mod crypto;
 pub use wallet_core_common::aes;
 
 use core::result;
-pub use crypto::{Crypto, EncPair, KdfParams, Key, Pbkdf2Params, SCryptParams};
+pub use crypto::{Argon2idParams, Crypto, EncPair, KdfParams, Key, Pbkdf2Params, SCryptParams};
 use parking_lot::RwLock;
 
 #[macro_use]
@@ -33,5 +33,5 @@ lazy_static! {
         RwLock::new("B888D25EC8C12BD5043777B1AC49F872".to_string());
     pub static ref XPUB_COMMON_IV: RwLock<String> =
         RwLock::new("9C0C30889CBCC5E01AB5B2BB88715799".to_string());
-    pub static ref KDF_ROUNDS: RwLock<i32> = RwLock::new(262144);
+    pub static ref KDF_ROUNDS: RwLock<i32> = RwLock::new(600000);
 }

--- a/token-core/tcx-docs/API.zh.md
+++ b/token-core/tcx-docs/API.zh.md
@@ -35,6 +35,10 @@ message HdStoreImportParam {
 TransactionInput 将作为SignTxParam中的input字段传入。如需要其他字段也可以放入其中。示例参见[btc-fork.proto](../tcx-proto/src/btc-fork.proto), [handler.rs#sign_tx](../tcx/src/handler.rs)。    
 编写完成之后配置`tcx-proto`中`build.rs`文件，将新定义的结构编译到链所在的package中即可使用。    
 
+## Keystore KDF 策略
+
+新创建的 TokenCoreX keystore 默认使用 `argon2id` 作为 KDF。历史 keystore 中已有的 `pbkdf2` 和 `scrypt` 格式继续按原 JSON 参数解锁，不做自动破坏性迁移。完整参数、兼容策略和安全说明见 [KDF 策略](./KDF.zh.md)。
+
 ## 安全敏感接口边界
 
 以下接口不属于默认生产构建的公共 API：

--- a/token-core/tcx-docs/API.zh.md
+++ b/token-core/tcx-docs/API.zh.md
@@ -34,3 +34,35 @@ message HdStoreImportParam {
 对于链的开发者，因为每个链需要签名结构不同，需要自行编写 _chain_.proto 并且定义链相关的TransactionInput 和 TransactionOutput。    
 TransactionInput 将作为SignTxParam中的input字段传入。如需要其他字段也可以放入其中。示例参见[btc-fork.proto](../tcx-proto/src/btc-fork.proto), [handler.rs#sign_tx](../tcx/src/handler.rs)。    
 编写完成之后配置`tcx-proto`中`build.rs`文件，将新定义的结构编译到链所在的package中即可使用。    
+
+## 安全敏感接口边界
+
+以下接口不属于默认生产构建的公共 API：
+
+- `get_derived_key`：用于 `cache_dk` 场景，返回可直接解锁 keystore 的派生密钥。默认不编译进 `tcx` 的 `call_tcx_api` method table；只有显式启用 `tcx` crate 的 `cache_dk` feature 时可用。
+- `unlock_then_crash`：仅用于验证 panic 后 keystore 会重新锁定的测试入口。默认不编译进 `call_tcx_api` method table；只有显式启用 `test_api` feature 时可用。
+
+默认构建中调用这些 method 会返回 `unsupported_method`。如确需验证这些入口，应使用显式 feature：
+
+```bash
+cargo test -p tcx --features cache_dk
+cargo test -p tcx --features test_api -- --ignored
+```
+
+对外发布或普通集成构建不应启用 `test_api`。`cache_dk` 只应在移动端派生密钥缓存等明确场景中启用，并且需要由上层安全设计保证 derived key 的生命周期、存储介质和访问控制。
+
+## 签名 API 命名约定
+
+推荐新调用方使用语义更清晰的 method 名：
+
+- `sign_transaction`：交易签名。兼容旧 method `sign_tx`。
+- `sign_message`：消息签名。兼容旧 method `sign_msg`。
+- `sign_raw_hashes`：对调用方已经确认语义的 digest/hash 做签名。兼容旧 method `sign_hashes`。
+- `eth_batch_personal_sign`：ETH `personal_sign` 批量签名，语义已经明确，继续作为推荐 method。
+
+旧 method 会继续保留以兼容已有 Java/Swift 调用方。新增代码应优先使用推荐 method，避免只看到 `sign_msg` 或 `ecSign` 时误判签名 payload 的安全语义。
+
+ETH 消息签名里的 `SignatureType` 语义如下：
+
+- `PersonalSign`：按 Ethereum `personal_sign` 规则加入前缀后签名，适用于普通用户可读消息。
+- `EcSign`：对 `keccak256(message)` 做裸 secp256k1 签名，保留给历史调用方。除非上层协议已经明确 payload 域、编码和重放保护，否则不建议新场景直接使用。

--- a/token-core/tcx-docs/KDF.zh.md
+++ b/token-core/tcx-docs/KDF.zh.md
@@ -1,0 +1,85 @@
+# Keystore KDF 策略
+
+TokenCoreX keystore 使用密码派生函数（KDF）从用户密码派生加密密钥，再用该密钥保护助记词、私钥和 identity 相关加密字段。
+
+## 默认策略
+
+新创建的 TokenCoreX keystore 默认使用 `argon2id`：
+
+```json
+{
+  "kdf": "argon2id",
+  "kdfparams": {
+    "memoryCost": 19456,
+    "timeCost": 2,
+    "parallelism": 1,
+    "dklen": 64,
+    "salt": "<32-byte hex salt>"
+  }
+}
+```
+
+参数含义：
+
+- `memoryCost`：Argon2id 内存成本，单位是 KiB。默认 `19456`，即 19 MiB。
+- `timeCost`：迭代次数。默认 `2`。
+- `parallelism`：并行度。默认 `1`，便于移动端和 wasm 场景保持稳定。
+- `dklen`：派生密钥长度。当前 TokenCoreX 使用 64 字节派生密钥。
+- `salt`：随机盐，hex 编码。新建 keystore 使用 32 字节随机盐。
+
+该参数组合参考 OWASP Password Storage Cheat Sheet 对 Argon2id 的最低建议，用于替代 PBKDF2 作为新建 keystore 的默认 KDF。
+
+## KDF matrix
+
+| 场景 | Legacy / current | Target | 处理结论 |
+| --- | --- | --- | --- |
+| 新建 `HdKeystore` / mnemonic keystore | 历史版本默认 `pbkdf2`，默认 rounds 曾为 `262144` | `argon2id`，`m=19456 KiB, t=2, p=1, dklen=64` | 已切换为新默认。 |
+| 新建 private-key keystore | 历史版本默认 `pbkdf2`，默认 rounds 曾为 `262144` | `argon2id`，`m=19456 KiB, t=2, p=1, dklen=64` | 已切换为新默认。 |
+| 显式 PBKDF2 fallback | `pbkdf2-hmac-sha256` | work factor `600000+` | `Pbkdf2Params::default()` 已提升到 `600000`；已有 JSON 仍按文件内 `c` 解锁。 |
+| 显式 scrypt fallback | `SCryptParams::default()` 为 `N=2^18, r=8, p=1` | 至少 `N=2^17, r=8, p=1` | 已高于 OWASP fallback 建议。 |
+| 导入 / 解锁旧 TokenCoreX keystore | JSON 中可能是 `pbkdf2` 或 `scrypt` | 继续可读 | 不自动改写；按原 `kdfparams` 解锁。 |
+| migration / upgrade 生成的新 TokenCoreX keystore | 旧代码路径调用 `Crypto::new` 生成 PBKDF2 | 新生成结果使用 `argon2id` | 随 `Crypto::new` 切换；历史 fixture 不重写。 |
+| Substrate / Polkadot.js keystore | `scrypt N=2^15, r=8, p=1`，编码在 PJS keystore 格式内 | 保持 PJS 兼容 | 不升级到 `2^17`，否则会破坏 Polkadot.js keystore 互通。 |
+
+## 兼容策略
+
+旧 keystore 不做破坏性迁移，仍按其 JSON 中的 `kdf` 字段解锁：
+
+- `argon2id`：新默认格式。
+- `pbkdf2`：历史 TokenCoreX keystore 继续支持。
+- `scrypt`：历史 V3 / 迁移来源 keystore 继续支持。
+
+读取旧 keystore 时不会自动把 PBKDF2 或 scrypt 改写为 Argon2id。原因是 keystore 文件属于用户资产保护边界，自动重加密会改变持久化格式，并可能影响老客户端、备份恢复和跨版本回滚。
+
+如后续需要迁移旧 keystore，应通过显式的“重加密/升级 keystore”流程完成，并满足：
+
+- 用户已经完成密码校验或已持有合法 derived key。
+- 新旧格式都能被测试覆盖。
+- 迁移失败时旧文件可恢复。
+- 移动端、wasm 和历史备份恢复路径均确认兼容。
+
+当前结论是不增加 lazy upgrade：解锁旧 keystore 后只返回内存态明文或派生密钥，不隐式写回文件。后续如要支持升级，应新增显式 API 或迁移流程，并在持久化格式中记录可审计的升级结果。
+
+## PBKDF2 说明
+
+PBKDF2 继续作为历史格式兼容能力保留，不再作为新创建 keystore 的默认 KDF。已有 PBKDF2 keystore 的 `kdfparams.c`、`prf`、`dklen`、`salt` 按文件内记录解释，不统一修改。若调用方显式使用 PBKDF2 创建新加密体，默认 work factor 为 `600000`。
+
+测试环境可通过 `KDF_ROUNDS=1` 降低 PBKDF2 测试耗时。该环境变量只影响 PBKDF2 默认参数和测试速度，不代表生产默认配置，也不影响 Argon2id 默认参数。
+
+## profiling 数据
+
+仓库提供 ignored 测试用于记录本机 KDF 耗时：
+
+```bash
+cargo test -p tcx-crypto test_kdf_profile -- --ignored --nocapture
+```
+
+在当前 macOS 开发机、debug test profile 下的一次结果：
+
+| KDF | 参数 | 耗时 |
+| --- | --- | --- |
+| Argon2id | `m=19456 KiB, t=2, p=1` | 302 ms |
+| scrypt | `N=2^17, r=8, p=1` | 12942 ms |
+| PBKDF2-HMAC-SHA256 | `c=600000` | 8185 ms |
+
+该数据只作为本地 profiling 基线，不代表所有移动端设备的 SLA。参数选择的实际结论是：Argon2id 满足 OWASP 最低建议，并且在当前测试环境中明显低于 scrypt / PBKDF2 fallback 的耗时；如未来提高 Argon2id 参数，应先补移动端 release 构建 profiling。

--- a/token-core/tcx-eth/src/transaction.rs
+++ b/token-core/tcx-eth/src/transaction.rs
@@ -65,7 +65,11 @@ pub struct EthRecoverAddressOutput {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum SignatureType {
+    /// Ethereum personal_sign: hashes "\x19Ethereum Signed Message:\n" || len || message.
     PersonalSign = 0,
+    /// Raw secp256k1 signing over keccak256(message). This is kept for legacy
+    /// callers; prefer a domain-specific API such as transaction signing,
+    /// personal_sign, or typed-data signing when the payload semantics are known.
     EcSign = 1,
 }
 impl SignatureType {

--- a/token-core/tcx-keystore/src/keystore/guard.rs
+++ b/token-core/tcx-keystore/src/keystore/guard.rs
@@ -77,21 +77,24 @@ mod tests {
 
         assert!(ks.is_locked());
 
-        let mut ks = Keystore::from_private_key(
-            PRIVATE_KEY,
-            TEST_PASSWORD,
-            CurveType::SECP256k1,
-            Metadata::default(),
-            None,
-        )
-        .unwrap();
-        let derived_key = ks.get_derived_key(&TEST_PASSWORD).unwrap();
-
+        #[cfg(feature = "cache_dk")]
         {
-            let guard = KeystoreGuard::unlock_by_derived_key(&mut ks, &derived_key).unwrap();
-            assert!(!guard.keystore().is_locked());
-        }
+            let mut ks = Keystore::from_private_key(
+                PRIVATE_KEY,
+                TEST_PASSWORD,
+                CurveType::SECP256k1,
+                Metadata::default(),
+                None,
+            )
+            .unwrap();
+            let derived_key = ks.get_derived_key(&TEST_PASSWORD).unwrap();
 
-        assert!(ks.is_locked());
+            {
+                let guard = KeystoreGuard::unlock_by_derived_key(&mut ks, &derived_key).unwrap();
+                assert!(!guard.keystore().is_locked());
+            }
+
+            assert!(ks.is_locked());
+        }
     }
 }

--- a/token-core/tcx-keystore/src/keystore/hd.rs
+++ b/token-core/tcx-keystore/src/keystore/hd.rs
@@ -268,13 +268,17 @@ mod tests {
         let keystore =
             HdKeystore::from_mnemonic(TEST_MNEMONIC, TEST_PASSWORD, Metadata::default()).unwrap();
 
-        let derived_key = Keystore::Hd(keystore.clone())
-            .get_derived_key(TEST_PASSWORD)
-            .unwrap();
         assert!(keystore.verify_password(&Key::Password(TEST_PASSWORD.to_string())));
-        assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
         assert!(!keystore.verify_password(&Key::Password("WRONG PASSWORD".to_string())));
-        assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+
+        #[cfg(feature = "cache_dk")]
+        {
+            let derived_key = Keystore::Hd(keystore.clone())
+                .get_derived_key(TEST_PASSWORD)
+                .unwrap();
+            assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
+            assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        }
     }
 
     #[test]

--- a/token-core/tcx-keystore/src/keystore/mod.rs
+++ b/token-core/tcx-keystore/src/keystore/mod.rs
@@ -9,6 +9,7 @@ mod private;
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "cache_dk")]
 use tcx_common::ToHex;
 use tcx_constants::{CoinInfo, CurveType};
 
@@ -292,6 +293,7 @@ impl Keystore {
         }
     }
 
+    #[cfg(feature = "cache_dk")]
     pub fn get_derived_key(&mut self, password: &str) -> Result<String> {
         Ok(self
             .store_mut()
@@ -771,11 +773,14 @@ pub(crate) mod tests {
             "password_incorrect"
         );
 
-        let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
         assert!(keystore.verify_password(&Key::Password(TEST_PASSWORD.to_string())));
-        assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
         assert!(!keystore.verify_password(&Key::Password("WRONG PASSWORD".to_string())));
-        assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        #[cfg(feature = "cache_dk")]
+        {
+            let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
+            assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
+            assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        }
         keystore.unlock_by_password(TEST_PASSWORD).unwrap();
         assert_eq!(
             "inject kidney empty canal shadow pact comfort wife crush horse wife sketch",
@@ -890,11 +895,14 @@ pub(crate) mod tests {
         assert!(keystore.identity().identifier.starts_with("im"));
         assert_eq!(keystore.meta().name, "Unknown");
         assert_ne!(keystore.id(), "");
-        let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
         assert!(keystore.verify_password(&Key::Password(TEST_PASSWORD.to_string())));
-        assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
         assert!(!keystore.verify_password(&Key::Password("WRONG PASSWORD".to_string())));
-        assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        #[cfg(feature = "cache_dk")]
+        {
+            let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
+            assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
+            assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        }
 
         let coin_info = CoinInfo {
             chain_id: "".to_string(),
@@ -964,11 +972,14 @@ pub(crate) mod tests {
             format!("{}", keystore.export().unwrap()),
             TEST_PRIVATE_KEY.to_string()
         );
-        let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
         assert!(keystore.verify_password(&Key::Password(TEST_PASSWORD.to_string())));
-        assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
         assert!(!keystore.verify_password(&Key::Password("WRONG PASSWORD".to_string())));
-        assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        #[cfg(feature = "cache_dk")]
+        {
+            let derived_key = keystore.get_derived_key(TEST_PASSWORD).unwrap();
+            assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
+            assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        }
 
         let coin_info = CoinInfo {
             chain_id: "".to_string(),

--- a/token-core/tcx-keystore/src/keystore/private.rs
+++ b/token-core/tcx-keystore/src/keystore/private.rs
@@ -217,13 +217,17 @@ mod tests {
         )
         .unwrap();
 
-        let derived_key = Keystore::PrivateKey(keystore.clone())
-            .get_derived_key(TEST_PASSWORD)
-            .unwrap();
         assert!(keystore.verify_password(&Key::Password(TEST_PASSWORD.to_string())));
-        assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
         assert!(!keystore.verify_password(&Key::Password("WRONG PASSWORD".to_string())));
-        assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+
+        #[cfg(feature = "cache_dk")]
+        {
+            let derived_key = Keystore::PrivateKey(keystore.clone())
+                .get_derived_key(TEST_PASSWORD)
+                .unwrap();
+            assert!(keystore.verify_password(&Key::DerivedKey(derived_key.to_string())));
+            assert!(!keystore.verify_password(&Key::DerivedKey("731dd44109f9897eb39980907161b7531be44714352ddaa40542da22fb4fab7533678f2e132226389174faad4e653c542811a7b0c9391ae3cce4e75039a15adc".to_string())));
+        }
     }
 
     #[test]

--- a/token-core/tcx-proto/src/cache_derived_key.proto
+++ b/token-core/tcx-proto/src/cache_derived_key.proto
@@ -6,6 +6,11 @@ message VerifyDerivedKeyParam {
     string derivedKey = 2;
 }
 
+// Sensitive cache-derived-key API.
+//
+// `get_derived_key` is not part of the default public production API surface.
+// It is compiled into tcx only when the `cache_dk` feature is explicitly
+// enabled for mobile/key-cache integration tests or platform-specific builds.
 message DerivedKeyResult {
     string id = 1;
     string derivedKey = 2;

--- a/token-core/tcx-proto/src/eth.proto
+++ b/token-core/tcx-proto/src/eth.proto
@@ -31,7 +31,11 @@ message EthMessageInput {
 }
 
 enum SignatureType {
+  // Ethereum personal_sign: hashes "\x19Ethereum Signed Message:\n" || len || message.
   PersonalSign = 0;
+  // Raw secp256k1 signing over keccak256(message). This is kept for legacy
+  // callers; prefer a domain-specific API such as transaction signing,
+  // personal_sign, or typed-data signing when the payload semantics are known.
   EcSign = 1;
 }
 

--- a/token-core/tcx-proto/src/params.proto
+++ b/token-core/tcx-proto/src/params.proto
@@ -145,6 +145,13 @@ message ImportJsonParam {
 }
 
 
+// Common chain signing parameter.
+//
+// Recommended TcxAction method names:
+// - `sign_transaction`: transaction signing; legacy alias `sign_tx`.
+// - `sign_message`: chain message signing; legacy alias `sign_msg`.
+//
+// The concrete input type is chain-specific and is carried in `input`.
 message SignParam {
   string id = 1;
   oneof key {

--- a/token-core/tcx/Cargo.toml
+++ b/token-core/tcx/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 tcx-proto = { path = "../tcx-proto" }
-tcx-crypto = { path = "../tcx-crypto", features = ["cache_dk"] }
-tcx-keystore = { path = "../tcx-keystore", features = ["cache_dk"] }
+tcx-crypto = { path = "../tcx-crypto" }
+tcx-keystore = { path = "../tcx-keystore" }
 tcx-btc-kin = { path = "../tcx-btc-kin" }
 tcx-tron = { path = "../tcx-tron" }
 tcx-ckb = { path = "../tcx-ckb" }
@@ -44,6 +44,11 @@ ethereum-types = "=0.16.0"
 strum = { version = "=0.28.0", features = ["derive"] }
 sp-core = "=41.0.0"
 schnorrkel = "=0.11.5"
+
+[features]
+default = []
+cache_dk = ["tcx-crypto/cache_dk", "tcx-keystore/cache_dk"]
+test_api = []
 
 [lib]
 name = "tcx"

--- a/token-core/tcx/README.md
+++ b/token-core/tcx/README.md
@@ -1,3 +1,14 @@
 # TokenCoreX API Layer
 
 This package is used to exposed all API.
+
+## Security-sensitive features
+
+The default build keeps test/debug-only methods out of `call_tcx_api`.
+
+- `cache_dk`: enables `get_derived_key` for explicit derived-key cache integrations.
+- `test_api`: enables `unlock_then_crash` for panic/lock-state tests only.
+
+Production builds should not enable `test_api`. New callers should prefer
+`sign_transaction`, `sign_message`, and `sign_raw_hashes`; legacy aliases
+`sign_tx`, `sign_msg`, and `sign_hashes` remain available for compatibility.

--- a/token-core/tcx/src/api.rs
+++ b/token-core/tcx/src/api.rs
@@ -455,6 +455,13 @@ pub struct ImportJsonParam {
     #[prost(bool, tag = "3")]
     pub overwrite: bool,
 }
+/// Common chain signing parameter.
+///
+/// Recommended TcxAction method names:
+/// - `sign_transaction`: transaction signing; legacy alias `sign_tx`.
+/// - `sign_message`: chain message signing; legacy alias `sign_msg`.
+///
+/// The concrete input type is chain-specific and is carried in `input`.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct SignParam {
     #[prost(string, tag = "1")]
@@ -696,6 +703,11 @@ pub struct VerifyDerivedKeyParam {
     #[prost(string, tag = "2")]
     pub derived_key: ::prost::alloc::string::String,
 }
+/// Sensitive cache-derived-key API.
+///
+/// `get_derived_key` is not part of the default public production API surface.
+/// It is compiled into tcx only when the `cache_dk` feature is explicitly
+/// enabled for mobile/key-cache integration tests or platform-specific builds.
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct DerivedKeyResult {
     #[prost(string, tag = "1")]

--- a/token-core/tcx/src/handler.rs
+++ b/token-core/tcx/src/handler.rs
@@ -29,10 +29,12 @@ use tcx_crypto::{XPUB_COMMON_IV, XPUB_COMMON_KEY_128};
 use tcx_filecoin::KeyInfo;
 
 use crate::api::derive_accounts_param::Derivation;
+#[cfg(feature = "cache_dk")]
+use crate::api::DerivedKeyResult;
 use crate::api::{
-    self, export_private_key_param, AccountResponse, BackupResult, CreateKeystoreParam,
+    export_private_key_param, AccountResponse, BackupResult, CreateKeystoreParam,
     DecryptDataFromIpfsParam, DecryptDataFromIpfsResult, DeriveAccountsParam, DeriveAccountsResult,
-    DeriveSubAccountsParam, DeriveSubAccountsResult, DerivedKeyResult, EncryptDataToIpfsParam,
+    DeriveSubAccountsParam, DeriveSubAccountsResult, EncryptDataToIpfsParam,
     EncryptDataToIpfsResult, ExistsJsonParam, ExistsKeystoreResult, ExistsMnemonicParam,
     ExistsPrivateKeyParam, ExportJsonParam, ExportJsonResult, ExportMnemonicParam,
     ExportMnemonicResult, ExportPrivateKeyParam, ExportPrivateKeyResult, GeneralResult,
@@ -1308,6 +1310,7 @@ pub(crate) fn sign_psbts(data: &[u8]) -> Result<Vec<u8>> {
     )?)
 }
 
+#[cfg(feature = "cache_dk")]
 pub fn get_derived_key(data: &[u8]) -> Result<Vec<u8>> {
     let param: WalletKeyParam = WalletKeyParam::decode(data).expect("get_derived_key param");
     let mut map: parking_lot::lock_api::RwLockWriteGuard<
@@ -1320,7 +1323,7 @@ pub fn get_derived_key(data: &[u8]) -> Result<Vec<u8>> {
         _ => Err(anyhow!("{}", "wallet_not_found")),
     }?;
 
-    let Some(api::wallet_key_param::Key::Password(password)) = param.key else {
+    let Some(crate::api::wallet_key_param::Key::Password(password)) = param.key else {
         return Err(anyhow!("{}", "get_derived_key need password"));
     };
     let dk = keystore.get_derived_key(&password)?;
@@ -1503,6 +1506,7 @@ pub(crate) fn backup(data: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
+#[cfg(feature = "test_api")]
 pub(crate) fn unlock_then_crash(data: &[u8]) -> Result<Vec<u8>> {
     let param: WalletKeyParam = WalletKeyParam::decode(data).unwrap();
     let mut map = KEYSTORE_MAP.write();

--- a/token-core/tcx/src/lib.rs
+++ b/token-core/tcx/src/lib.rs
@@ -21,13 +21,17 @@ use anyhow::Error;
 use std::result;
 
 use crate::error_handling::{landingpad, LAST_ERROR};
+#[cfg(feature = "cache_dk")]
+use crate::handler::get_derived_key;
+#[cfg(feature = "test_api")]
+use crate::handler::unlock_then_crash;
 use crate::handler::{
     create_keystore, decrypt_data_from_ipfs, delete_keystore, derive_accounts, derive_sub_accounts,
     encode_message, encrypt_data_to_ipfs, eth_batch_personal_sign, exists_json, exists_mnemonic,
-    exists_private_key, export_json, export_mnemonic, export_private_key, get_derived_key,
-    get_extended_public_keys, get_public_keys, import_json, import_mnemonic, import_private_key,
-    mnemonic_to_public, scan_keystores, sign_authentication_message, sign_hashes, sign_message,
-    sign_psbt, sign_psbts, sign_tx, unlock_then_crash, verify_password,
+    exists_private_key, export_json, export_mnemonic, export_private_key, get_extended_public_keys,
+    get_public_keys, import_json, import_mnemonic, import_private_key, mnemonic_to_public,
+    scan_keystores, sign_authentication_message, sign_hashes, sign_message, sign_psbt, sign_psbts,
+    sign_tx, verify_password,
 };
 use crate::migration::{migrate_keystore, scan_legacy_keystores};
 
@@ -96,16 +100,16 @@ pub unsafe extern "C" fn call_tcx_api(hex_str: *const c_char) -> *const c_char {
         "exists_mnemonic" => landingpad(|| exists_mnemonic(&action.param.unwrap().value)),
         "exists_private_key" => landingpad(|| exists_private_key(&action.param.unwrap().value)),
         "derive_sub_accounts" => landingpad(|| derive_sub_accounts(&action.param.unwrap().value)),
-        "sign_tx" => landingpad(|| sign_tx(&action.param.unwrap().value)),
-        "sign_msg" => landingpad(|| sign_message(&action.param.unwrap().value)),
+        "sign_tx" | "sign_transaction" => landingpad(|| sign_tx(&action.param.unwrap().value)),
+        "sign_msg" | "sign_message" => landingpad(|| sign_message(&action.param.unwrap().value)),
         "exists_json" => landingpad(|| exists_json(&action.param.unwrap().value)),
         "import_json" => landingpad(|| import_json(&action.param.unwrap().value)),
         "export_json" => landingpad(|| export_json(&action.param.unwrap().value)),
         "backup" => landingpad(|| backup(&action.param.unwrap().value)),
 
-        // !!! WARNING !!! used for `cache_dk` feature
+        #[cfg(feature = "cache_dk")]
         "get_derived_key" => landingpad(|| get_derived_key(&action.param.unwrap().value)),
-        // !!! WARNING !!! used for test only
+        #[cfg(feature = "test_api")]
         "unlock_then_crash" => landingpad(|| unlock_then_crash(&action.param.unwrap().value)),
 
         "encrypt_data_to_ipfs" => landingpad(|| encrypt_data_to_ipfs(&action.param.unwrap().value)),
@@ -121,7 +125,9 @@ pub unsafe extern "C" fn call_tcx_api(hex_str: *const c_char) -> *const c_char {
             landingpad(|| get_extended_public_keys(&action.param.unwrap().value))
         }
         "get_public_keys" => landingpad(|| get_public_keys(&action.param.unwrap().value)),
-        "sign_hashes" => landingpad(|| sign_hashes(&action.param.unwrap().value)),
+        "sign_hashes" | "sign_raw_hashes" => {
+            landingpad(|| sign_hashes(&action.param.unwrap().value))
+        }
         "mnemonic_to_public" => landingpad(|| mnemonic_to_public(&action.param.unwrap().value)),
         "sign_bls_to_execution_change" => {
             landingpad(|| sign_bls_to_execution_change(&action.param.unwrap().value))

--- a/token-core/tcx/tests/export_test.rs
+++ b/token-core/tcx/tests/export_test.rs
@@ -5,16 +5,19 @@ mod common;
 
 use tcx::api::derive_accounts_param::Derivation;
 
+#[cfg(feature = "cache_dk")]
 use tcx::handler::cache_keystores;
 use tcx::*;
 
 use prost::Message;
+#[cfg(feature = "cache_dk")]
+use tcx::api::DerivedKeyResult;
 use tcx::api::{
     export_private_key_param, BackupResult, DeriveAccountsParam, DeriveAccountsResult,
-    DerivedKeyResult, ExistsKeystoreResult, ExistsPrivateKeyParam, ExportMnemonicResult,
-    ExportPrivateKeyParam, ExportPrivateKeyResult, GetPublicKeysParam, GetPublicKeysResult,
-    ImportJsonParam, ImportMnemonicParam, ImportPrivateKeyParam, ImportPrivateKeyResult,
-    KeystoreResult, PublicKeyDerivation, WalletKeyParam,
+    ExistsKeystoreResult, ExistsPrivateKeyParam, ExportMnemonicResult, ExportPrivateKeyParam,
+    ExportPrivateKeyResult, GetPublicKeysParam, GetPublicKeysResult, ImportJsonParam,
+    ImportMnemonicParam, ImportPrivateKeyParam, ImportPrivateKeyResult, KeystoreResult,
+    PublicKeyDerivation, WalletKeyParam,
 };
 
 use tcx::handler::{encode_message, import_private_key};
@@ -564,27 +567,30 @@ pub fn test_backup_v3_keystore() {
             .original
             .contains("0x6031564e7b2F5cc33737807b2E58DaFF870B590b"));
 
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::Password(
-                TEST_PASSWORD.to_owned(),
-            )),
-        };
+        #[cfg(feature = "cache_dk")]
+        {
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::Password(
+                    TEST_PASSWORD.to_owned(),
+                )),
+            };
 
-        let ret = call_api("get_derived_key", param).unwrap();
-        let derived_key_result: DerivedKeyResult =
-            DerivedKeyResult::decode(ret.as_slice()).unwrap();
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::DerivedKey(
-                derived_key_result.derived_key,
-            )),
-        };
-        let ret = call_api("backup", param).unwrap();
-        let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
-        assert!(export_result
-            .original
-            .contains("0x6031564e7b2F5cc33737807b2E58DaFF870B590b"));
+            let ret = call_api("get_derived_key", param).unwrap();
+            let derived_key_result: DerivedKeyResult =
+                DerivedKeyResult::decode(ret.as_slice()).unwrap();
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::DerivedKey(
+                    derived_key_result.derived_key,
+                )),
+            };
+            let ret = call_api("backup", param).unwrap();
+            let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
+            assert!(export_result
+                .original
+                .contains("0x6031564e7b2F5cc33737807b2E58DaFF870B590b"));
+        }
     })
 }
 
@@ -635,27 +641,30 @@ pub fn test_backup_pjs_kystore() {
             .original
             .contains("JHBkzZJnLZ3S3HLvxjpFAjd6ywP7WAk5miL7MwVCn9a7jHS"));
 
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::Password(
-                TEST_PASSWORD.to_owned(),
-            )),
-        };
+        #[cfg(feature = "cache_dk")]
+        {
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::Password(
+                    TEST_PASSWORD.to_owned(),
+                )),
+            };
 
-        let ret = call_api("get_derived_key", param).unwrap();
-        let derived_key_result: DerivedKeyResult =
-            DerivedKeyResult::decode(ret.as_slice()).unwrap();
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::DerivedKey(
-                derived_key_result.derived_key,
-            )),
-        };
-        let ret = call_api("backup", param).unwrap();
-        let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
-        assert!(export_result
-            .original
-            .contains("JHBkzZJnLZ3S3HLvxjpFAjd6ywP7WAk5miL7MwVCn9a7jHS"));
+            let ret = call_api("get_derived_key", param).unwrap();
+            let derived_key_result: DerivedKeyResult =
+                DerivedKeyResult::decode(ret.as_slice()).unwrap();
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::DerivedKey(
+                    derived_key_result.derived_key,
+                )),
+            };
+            let ret = call_api("backup", param).unwrap();
+            let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
+            assert!(export_result
+                .original
+                .contains("JHBkzZJnLZ3S3HLvxjpFAjd6ywP7WAk5miL7MwVCn9a7jHS"));
+        }
     })
 }
 
@@ -694,31 +703,34 @@ pub fn test_backup_private_key() {
         let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
         assert_eq!(export_result.original, TEST_WIF);
 
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::Password(
-                TEST_PASSWORD.to_owned(),
-            )),
-        };
+        #[cfg(feature = "cache_dk")]
+        {
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::Password(
+                    TEST_PASSWORD.to_owned(),
+                )),
+            };
 
-        let ret = call_api("get_derived_key", param).unwrap();
-        let derived_key_result: DerivedKeyResult =
-            DerivedKeyResult::decode(ret.as_slice()).unwrap();
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::DerivedKey(
-                derived_key_result.derived_key,
-            )),
-        };
-        let ret = call_api("backup", param.clone()).unwrap();
-        let backup_result = BackupResult::decode(ret.as_slice()).unwrap();
-        assert_eq!(backup_result.original, TEST_WIF);
+            let ret = call_api("get_derived_key", param).unwrap();
+            let derived_key_result: DerivedKeyResult =
+                DerivedKeyResult::decode(ret.as_slice()).unwrap();
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::DerivedKey(
+                    derived_key_result.derived_key,
+                )),
+            };
+            let ret = call_api("backup", param.clone()).unwrap();
+            let backup_result = BackupResult::decode(ret.as_slice()).unwrap();
+            assert_eq!(backup_result.original, TEST_WIF);
 
-        change_fingerprint_in_keystore(&import_result.id, &import_result.source_fingerprint);
-        cache_keystores().unwrap();
+            change_fingerprint_in_keystore(&import_result.id, &import_result.source_fingerprint);
+            cache_keystores().unwrap();
 
-        let ret = call_api("backup", param);
-        assert_eq!(format!("{}", ret.err().unwrap()), "fingerprint_not_match");
+            let ret = call_api("backup", param);
+            assert_eq!(format!("{}", ret.err().unwrap()), "fingerprint_not_match");
+        }
     })
 }
 
@@ -747,34 +759,38 @@ pub fn test_backup_mnemonic() {
         let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
         assert_eq!(export_result.original, TEST_MNEMONIC.to_string());
 
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::Password(
-                TEST_PASSWORD.to_owned(),
-            )),
-        };
+        #[cfg(feature = "cache_dk")]
+        {
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::Password(
+                    TEST_PASSWORD.to_owned(),
+                )),
+            };
 
-        let ret = call_api("get_derived_key", param).unwrap();
-        let derived_key_result: DerivedKeyResult =
-            DerivedKeyResult::decode(ret.as_slice()).unwrap();
-        let param = WalletKeyParam {
-            id: import_result.id.to_string(),
-            key: Some(api::wallet_key_param::Key::DerivedKey(
-                derived_key_result.derived_key,
-            )),
-        };
-        let ret = call_api("backup", param.clone()).unwrap();
-        let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
-        assert_eq!(export_result.original, TEST_MNEMONIC.to_string());
+            let ret = call_api("get_derived_key", param).unwrap();
+            let derived_key_result: DerivedKeyResult =
+                DerivedKeyResult::decode(ret.as_slice()).unwrap();
+            let param = WalletKeyParam {
+                id: import_result.id.to_string(),
+                key: Some(api::wallet_key_param::Key::DerivedKey(
+                    derived_key_result.derived_key,
+                )),
+            };
+            let ret = call_api("backup", param.clone()).unwrap();
+            let export_result: BackupResult = BackupResult::decode(ret.as_slice()).unwrap();
+            assert_eq!(export_result.original, TEST_MNEMONIC.to_string());
 
-        change_fingerprint_in_keystore(&import_result.id, &import_result.source_fingerprint);
-        cache_keystores().unwrap();
+            change_fingerprint_in_keystore(&import_result.id, &import_result.source_fingerprint);
+            cache_keystores().unwrap();
 
-        let ret = call_api("backup", param);
-        assert_eq!(format!("{}", ret.err().unwrap()), "fingerprint_not_match");
+            let ret = call_api("backup", param);
+            assert_eq!(format!("{}", ret.err().unwrap()), "fingerprint_not_match");
+        }
     })
 }
 
+#[cfg(feature = "cache_dk")]
 fn change_fingerprint_in_keystore(id: &str, fingerprint: &str) {
     let file_path = format!("/tmp/imtoken/walletsV2/{}.json", id);
     let contents = fs::read_to_string(&file_path).unwrap();

--- a/token-core/tcx/tests/export_test.rs
+++ b/token-core/tcx/tests/export_test.rs
@@ -24,6 +24,7 @@ use tcx::handler::{encode_message, import_private_key};
 use tcx_constants::{CurveType, TEST_WIF};
 use tcx_constants::{TEST_MNEMONIC, TEST_PASSWORD};
 
+#[cfg(feature = "cache_dk")]
 use std::fs;
 
 use crate::common::*;

--- a/token-core/tcx/tests/other_test.rs
+++ b/token-core/tcx/tests/other_test.rs
@@ -8,14 +8,18 @@ mod common;
 use tcx::*;
 
 use prost::Message;
+#[cfg(feature = "cache_dk")]
+use tcx::api::DerivedKeyResult;
 use tcx::api::{
-    DecryptDataFromIpfsParam, DecryptDataFromIpfsResult, DerivedKeyResult, EncryptDataToIpfsParam,
+    DecryptDataFromIpfsParam, DecryptDataFromIpfsResult, EncryptDataToIpfsParam,
     EncryptDataToIpfsResult, ExistsKeystoreResult, ExistsMnemonicParam, ExistsPrivateKeyParam,
     GeneralResult, ImportPrivateKeyParam, KeystoreResult, SignAuthenticationMessageParam,
     SignAuthenticationMessageResult, WalletKeyParam,
 };
 
-use tcx::handler::{encode_message, get_derived_key, import_private_key};
+#[cfg(feature = "cache_dk")]
+use tcx::handler::get_derived_key;
+use tcx::handler::{encode_message, import_private_key};
 
 use tcx_constants::{TEST_MNEMONIC, TEST_PASSWORD};
 
@@ -52,6 +56,42 @@ pub fn test_verify_password() {
             assert!(ret.is_err());
             assert_eq!(format!("{}", ret.err().unwrap()), "password_incorrect");
         }
+    })
+}
+
+#[test]
+#[serial]
+#[cfg(not(feature = "cache_dk"))]
+pub fn test_get_derived_key_is_not_in_default_api_table() {
+    run_test(|| {
+        let wallet = import_default_wallet();
+        let param = WalletKeyParam {
+            id: wallet.id,
+            key: Some(api::wallet_key_param::Key::Password(
+                TEST_PASSWORD.to_owned(),
+            )),
+        };
+
+        let ret = call_api("get_derived_key", param);
+        assert_eq!(format!("{}", ret.err().unwrap()), "unsupported_method");
+    })
+}
+
+#[test]
+#[serial]
+#[cfg(not(feature = "test_api"))]
+pub fn test_unlock_then_crash_is_not_in_default_api_table() {
+    run_test(|| {
+        let wallet = import_default_wallet();
+        let param = WalletKeyParam {
+            id: wallet.id,
+            key: Some(api::wallet_key_param::Key::Password(
+                TEST_PASSWORD.to_owned(),
+            )),
+        };
+
+        let ret = call_api("unlock_then_crash", param);
+        assert_eq!(format!("{}", ret.err().unwrap()), "unsupported_method");
     })
 }
 
@@ -105,6 +145,7 @@ pub fn test_delete_keystore_by_password() {
 
 #[test]
 #[serial]
+#[cfg(feature = "cache_dk")]
 pub fn test_delete_keystore_by_derived_key() {
     run_test(|| {
         let param: ImportPrivateKeyParam = ImportPrivateKeyParam {

--- a/token-core/tcx/tests/sign_test.rs
+++ b/token-core/tcx/tests/sign_test.rs
@@ -20,14 +20,20 @@ use prost::Message;
 use sp_core::ByteArray;
 use sp_runtime::traits::Verify;
 
+#[cfg(feature = "cache_dk")]
+use tcx::api::DerivedKeyResult;
+#[cfg(feature = "test_api")]
+use tcx::api::GeneralResult;
+#[cfg(any(feature = "cache_dk", feature = "test_api"))]
+use tcx::api::WalletKeyParam;
 use tcx::api::{
-    sign_param, DeriveAccountsParam, DeriveAccountsResult, DerivedKeyResult, GeneralResult,
-    GetPublicKeysParam, GetPublicKeysResult, ImportMnemonicParam, ImportPrivateKeyParam,
-    ImportPrivateKeyResult, KeystoreResult, PublicKeyDerivation, SignHashesParam, SignHashesResult,
-    SignParam, WalletKeyParam,
+    sign_param, DeriveAccountsParam, DeriveAccountsResult, GetPublicKeysParam, GetPublicKeysResult,
+    ImportMnemonicParam, ImportPrivateKeyParam, ImportPrivateKeyResult, KeystoreResult,
+    PublicKeyDerivation, SignHashesParam, SignHashesResult, SignParam,
 };
 
 use tcx::handler::encode_message;
+#[cfg(feature = "cache_dk")]
 use tcx::handler::get_derived_key;
 use tcx_btc_kin::transaction::{
     BtcKinTxInput, BtcMessageInput, BtcMessageOutput, BtcSignatureType,
@@ -47,6 +53,62 @@ use tcx_substrate::{SubstrateRawTxIn, SubstrateTxOut};
 use tcx_tezos::transaction::{TezosRawTxIn, TezosTxOut};
 use tcx_ton::transaction::{TonRawTxIn, TonTxOut};
 use tcx_tron::transaction::{TronMessageInput, TronMessageOutput, TronTxInput, TronTxOutput};
+
+#[test]
+#[serial]
+pub fn test_recommended_sign_transaction_alias() {
+    run_test(|| {
+        let wallet = import_default_wallet();
+        let raw_data = "0a0202a22208e216e254e43ee10840c8cbe4e3df2d5a67080112630a2d747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e5472616e73666572436f6e747261637412320a15415c68cc82c87446f602f019e5fd797437f5b79cc212154156a6076cd1537fa317c2606e4edfa4acd3e8e92e18a08d06709084e1e3df2d".to_string();
+        let input = TronTxInput { raw_data };
+        let tx = SignParam {
+            id: wallet.id.to_string(),
+            key: Some(Key::Password(TEST_PASSWORD.to_owned())),
+            chain_type: "TRON".to_string(),
+            path: "m/44'/195'/0'/0/0".to_string(),
+            curve: "secp256k1".to_string(),
+            network: "".to_string(),
+            seg_wit: "".to_string(),
+            input: Some(::prost_types::Any {
+                type_url: "imtoken".to_string(),
+                value: encode_message(input).unwrap(),
+            }),
+        };
+
+        let ret = call_api("sign_transaction", tx).unwrap();
+        let output: TronTxOutput = TronTxOutput::decode(ret.as_slice()).unwrap();
+        assert!(!output.signatures.is_empty());
+    })
+}
+
+#[test]
+#[serial]
+pub fn test_recommended_sign_message_alias() {
+    run_test(|| {
+        let wallet = import_default_wallet();
+        let input = EthMessageInput {
+            message: "hello imToken".to_string(),
+            signature_type: tcx_eth::transaction::SignatureType::PersonalSign as i32,
+        };
+        let tx = SignParam {
+            id: wallet.id.to_string(),
+            key: Some(Key::Password(TEST_PASSWORD.to_owned())),
+            chain_type: "ETHEREUM".to_string(),
+            path: "m/44'/60'/0'/0/0".to_string(),
+            curve: "secp256k1".to_string(),
+            network: "".to_string(),
+            seg_wit: "".to_string(),
+            input: Some(::prost_types::Any {
+                type_url: "imtoken".to_string(),
+                value: encode_message(input).unwrap(),
+            }),
+        };
+
+        let ret = call_api("sign_message", tx).unwrap();
+        let output: EthMessageOutput = EthMessageOutput::decode(ret.as_slice()).unwrap();
+        assert!(!output.signature.is_empty());
+    })
+}
 
 #[test]
 #[serial]
@@ -599,6 +661,7 @@ pub fn test_sign_filecoin_secp256k1() {
 
 #[test]
 #[serial]
+#[cfg(feature = "cache_dk")]
 pub fn test_sign_by_dk_in_pk_store() {
     run_test(|| {
         let import_result = import_default_pk_store();
@@ -891,6 +954,7 @@ fn test_bitcoin_sign_message_incompatible() {
 
 #[test]
 #[serial]
+#[cfg(feature = "cache_dk")]
 fn test_sign_by_dk_hd_store() {
     run_test(|| {
         let wallet = import_default_wallet();
@@ -1055,6 +1119,7 @@ pub fn test_lock_after_sign() {
 
 #[test]
 #[serial]
+#[cfg(feature = "test_api")]
 #[ignore = "this case is test panic"]
 fn test_panic_keystore_locked() {
     run_test(|| {
@@ -1239,7 +1304,7 @@ pub fn test_sign_hashes() {
             )),
             data_to_sign,
         };
-        let result_bytes = call_api("sign_hashes", param).unwrap();
+        let result_bytes = call_api("sign_raw_hashes", param).unwrap();
         let result = SignHashesResult::decode(result_bytes.as_slice()).unwrap();
         assert_eq!(result.signatures.get(0).unwrap(), "0x8fa5d4dfe4766de7896f0e32c5bee9baae47aaa843cf5f1a2587dd9aaedf8a8c4400cb31bdcb1e90ddfe6d309e57841204dbf53704e4c4da3a9d25e9b4a09dac31a3221a7aac76f58ca21854173303cf58f039770a9e2307966e89faf0e5e79e");
 


### PR DESCRIPTION
## 改动概述

本 PR 为开放源码质量改进的 *阶段五：安全敏感接口收敛*，基于 `feat/open-source-quality-phase-4` 继续收口默认公开 API 边界，并补齐 KDF 与签名接口的安全语义说明。

本次改动重点：

- 为安全敏感接口增加 *feature gate*，避免默认生产构建暴露测试/调试能力：
  - `get_derived_key` 仅在显式启用 `cache_dk` feature 时编译进 `call_tcx_api`
  - `unlock_then_crash` 仅在显式启用 `test_api` feature 时编译进 `call_tcx_api`
- 为默认构建补充回归测试，确保未开启 feature 时：
  - 调用 `get_derived_key` 返回 `unsupported_method`
  - 调用 `unlock_then_crash` 返回 `unsupported_method`
- 对依赖 `derived key` 的测试与 keystore 校验逻辑做条件编译收敛，避免默认测试路径继续隐式依赖敏感能力
- 重新评估默认创建 keystore 的 KDF 策略：
  - 新创建 keystore 的默认 KDF 从 `pbkdf2` 切换为 `argon2id`
  - 默认参数采用 `m=19456 KiB, t=2, p=1, dklen=64`
  - 显式 PBKDF2 fallback 的默认 work factor 提升到 `600000`
  - 旧 keystore 继续按文件内 `kdf` / `kdfparams` 解锁，不做破坏性自动迁移
- 新增 `token-core/tcx-docs/KDF.zh.md`，补充：
  - 默认 KDF 策略与参数说明
  - 新旧 keystore 的兼容矩阵
  - PBKDF2 / scrypt fallback 语义
  - KDF profiling 方法与基线数据说明
- 补充签名 API 的推荐命名与兼容别名：
  - `sign_transaction`（兼容 `sign_tx`）
  - `sign_message`（兼容 `sign_msg`）
  - `sign_raw_hashes`（兼容 `sign_hashes`）
- 为 `SignParam`、`DerivedKeyResult`、ETH `SignatureType` 增加更明确的注释与文档，降低 `EcSign` / 原始 hash 签名的误用风险
- 更新 `README` 与 `API.zh.md`，明确：
  - 哪些接口不属于默认 public production API surface
  - 哪些接口仅用于测试或特定集成场景
  - 新旧签名方法的推荐用法与兼容关系

## 背景与目标

阶段五的目标是进一步收敛安全敏感能力的默认暴露面，避免开源使用方或普通集成方误将测试/调试入口当作稳定公共 API 使用。

同时，本阶段还处理两类安全语义问题：

- *KDF 策略问题*：PBKDF2 已不适合作为新系统默认 KDF，需要明确新建 keystore 的默认策略、fallback 语义和旧格式兼容边界
- *签名 API 命名问题*：`sign_tx` / `sign_msg` / `sign_hashes` / `EcSign` 等命名过于偏实现，容易弱化调用方对 payload 语义的判断

因此本阶段通过 *feature gate + KDF 策略更新 + 文档约束 + 推荐命名* 四个层面，收紧默认 API surface，并把默认安全行为与推荐调用方式讲清楚。

## 验证方式

已在本 PR 中补充/调整以下验证：

- 新增默认构建下的接口边界测试：
  - `test_get_derived_key_is_not_in_default_api_table`
  - `test_unlock_then_crash_is_not_in_default_api_table`
- 新增推荐签名别名测试：
  - `test_recommended_sign_transaction_alias`
  - `test_recommended_sign_message_alias`
- 新增 Argon2id / KDF 相关测试：
  - `test_derive_key_argon2id`
  - `test_kdf_type`
  - `test_kdfparams_trait_validate`
- 新增 ignored profiling 测试，用于本机比较 Argon2id / scrypt / PBKDF2 的耗时基线：
  - `test_kdf_profile`
- 将依赖 `cache_dk` / `test_api` 的既有测试改为条件编译，仅在对应 feature 打开时参与执行
- 文档中补充建议验证命令：
  - `cargo test -p tcx --features cache_dk`
  - `cargo test -p tcx --features test_api -- --ignored`
  - `cargo test -p tcx-crypto test_kdf_profile -- --ignored --nocapture`

## 其他说明

- 这是一个 *stacked PR*，base 为 `feat/open-source-quality-phase-4`
- 以兼容为前提保留旧方法名，降低对现有 Java / Swift 调用方的破坏性
- 旧 keystore 不做 lazy upgrade；后续若需要升级旧格式，应通过显式重加密/迁移流程完成
- 对外推荐调用方逐步迁移到更清晰的命名：`sign_transaction` / `sign_message` / `sign_raw_hashes`

## 截图（如适用）

不适用。

## 最终检查清单

- [ ] Did you test both iOS and Android(if applicable)?
- [ ] Is a security review needed(consenlabs/security)?

## 安全检查（仅供 leader check）

- [x] No backdoor risk
  - 本次主要为 API 暴露面收敛、KDF 默认策略更新、命名补充与测试条件编译调整，未新增不明网络请求或脚本入口
- [x] No network communication protocol risk
  - 未引入新的 http/ws 等网络通信协议风险
- [x] No import potentially risk 3rd library
  - 新增 `argon2` 依赖用于默认 KDF 切换，来源为标准 Rust crate 生态；未引入不明来源依赖
- [x] Private data not exposed
  - 本次改动目标之一就是避免默认构建暴露 `get_derived_key` 等敏感能力，并补充了 KDF 安全策略文档说明
